### PR TITLE
Enable the s390x architecture in release builds

### DIFF
--- a/.changeset/early-fans-guess.md
+++ b/.changeset/early-fans-guess.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-meetings-bot': patch
+---
+
+Enable the s390x architecture in release builds.

--- a/.github/workflows/publish-release-bot.yml
+++ b/.github/workflows/publish-release-bot.yml
@@ -58,6 +58,4 @@ jobs:
           context: .
           tags: ${{ steps.meta-new-tags.outputs.tags }}
           labels: ${{ steps.meta-new-tags.outputs.labels }}
-          # TODO: reenable s390x builds once the matrix-rust-sdk supports it
-          platforms: linux/amd64,linux/arm64
-          #platforms: linux/amd64,linux/arm64,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/s390x


### PR DESCRIPTION
This was missed from #75. We build containers for `s390x` but didn't include them in the release process.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
