### PR TITLE
Include the timezone definition in the exported calendar files

### DIFF
--- a/.changeset/famous-windows-stare.md
+++ b/.changeset/famous-windows-stare.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-meetings-widget': patch
+---
+
+Include the timezone definition in the exported calendar files.

--- a/matrix-meetings-widget/package.json
+++ b/matrix-meetings-widget/package.json
@@ -40,7 +40,8 @@
     "redux": "^4.2.1",
     "reselect": "^4.1.8",
     "rrule": "^2.7.2",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "timezones-ical-library": "^1.7.1"
   },
   "devDependencies": {
     "@craco/craco": "^7.1.0",

--- a/matrix-meetings-widget/src/components/meetings/MeetingCardShareMeetingContent/useDownloadIcsFile.test.tsx
+++ b/matrix-meetings-widget/src/components/meetings/MeetingCardShareMeetingContent/useDownloadIcsFile.test.tsx
@@ -27,7 +27,11 @@ import {
   mockMeetingSharingInformationEndpoint,
 } from '../../../lib/testUtils';
 import { createStore } from '../../../store';
-import { createIcsFile, useDownloadIcsFile } from './useDownloadIcsFile';
+import {
+  createIcsFile,
+  generateVTimezone,
+  useDownloadIcsFile,
+} from './useDownloadIcsFile';
 
 jest.mock('@matrix-widget-toolkit/api', () => ({
   ...jest.requireActual('@matrix-widget-toolkit/api'),
@@ -160,10 +164,31 @@ describe('createIcsFile', () => {
       "BEGIN:VCALENDAR
       VERSION:2.0
       PRODID:-//sebbo.net//ical-generator//EN
+      BEGIN:VTIMEZONE
+      TZID:Europe/Berlin
+      X-LIC-LOCATION:Europe/Berlin
+      LAST-MODIFIED:20230517T170335Z
+      BEGIN:DAYLIGHT
+      TZNAME:CEST
+      TZOFFSETFROM:+0100
+      TZOFFSETTO:+0200
+      DTSTART:19700329T020000
+      RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+      END:DAYLIGHT
+      BEGIN:STANDARD
+      TZNAME:CET
+      TZOFFSETFROM:+0200
+      TZOFFSETTO:+0100
+      DTSTART:19701025T030000
+      RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+      END:STANDARD
+      END:VTIMEZONE
+      TIMEZONE-ID:Europe/Berlin
+      X-WR-TIMEZONE:Europe/Berlin
       BEGIN:VEVENT
       UID:!meeting-room-id-entry-0
       SEQUENCE:0
-      DTSTAMP:20200101T100000Z
+      DTSTAMP:20200101T110000
       DTSTART;TZID=Europe/Berlin:29990101T100000
       DTEND;TZID=Europe/Berlin:29990101T140000
       SUMMARY:An important meeting
@@ -205,5 +230,15 @@ describe('createIcsFile', () => {
       END:VEVENT
       END:VCALENDAR"
     `);
+  });
+});
+
+describe('generateVTimezone', () => {
+  it('should return a string for a valid timezone', () => {
+    expect(generateVTimezone('Europe/Berlin')).toEqual(expect.any(String));
+  });
+
+  it('should skip invalid timezone', () => {
+    expect(generateVTimezone('NoContinent/NoCity')).toBeNull();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -12814,6 +12814,11 @@ thunky@^1.0.2:
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
 
+timezones-ical-library@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/timezones-ical-library/-/timezones-ical-library-1.7.1.tgz#638abce1cb96cc98003172f9a73491206848ad5c"
+  integrity sha512-kMklJHvitGSl51ewFyDuFmgN+QRM2y4FmW6bOSl+etzUfOkGVWRmoGAoyaNunmVFY5jw0Puezg2cXwvsgaOkFQ==
+
 timsort@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"


### PR DESCRIPTION
Resolves #196

This PR adds the `VTIMEZONE` section to the downloaded *.ics file.

Here are some example files for testing: [matrix-meetings events with timezone.zip](https://github.com/nordeck/matrix-meetings/files/12161867/matrix-meetings.events.with.timezone.zip)
* `01August2023_old.ics`: 01. August 2023 15:30 (Europe/Berlin) <b>before</b> this PR
* `01August2023_new.ics`: 01. August 2023 15:30 (Europe/Berlin) <b>after</b> this PR
* `01November2023_old.ics`: 01. November 2023 15:30 (Europe/Berlin) <b>before</b> this PR
* `01November2023_new.ics`: 01. November 2023 15:30 (Europe/Berlin) <b>after</b> this PR


<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [x] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
