### PR TITLE
Migrate meetings widget to Luxon

### DIFF
--- a/matrix-meetings-widget/package.json
+++ b/matrix-meetings-widget/package.json
@@ -28,8 +28,6 @@
     "lodash": "^4.17.20",
     "luxon": "^3.3.0",
     "matrix-widget-api": "^1.3.1",
-    "moment": "^2.29.3",
-    "moment-timezone": "^0.5.43",
     "mustache": "^4.2.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/matrix-meetings-widget/src/components/common/AdapterLuxonWeekday.test.ts
+++ b/matrix-meetings-widget/src/components/common/AdapterLuxonWeekday.test.ts
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2023 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DateTime } from 'luxon';
+import { setLocale } from '../../lib/locale';
+import { AdapterLuxonWeekday } from './AdapterLuxonWeekday';
+
+describe('AdapterLuxonWeekday', () => {
+  const adapter = new AdapterLuxonWeekday();
+
+  describe('for en locale', () => {
+    it('generate weekdays', () => {
+      expect(adapter.getWeekdays()).toEqual([
+        'S',
+        'M',
+        'T',
+        'W',
+        'T',
+        'F',
+        'S',
+      ]);
+    });
+
+    describe('for the month', () => {
+      const dateTime = DateTime.fromISO('2020-01-05T00:00:00Z');
+
+      it('week array should start on Sunday', () => {
+        const weeks = adapter.getWeekArray(dateTime);
+        expect(weeks[0][0].weekday).toEqual(7);
+      });
+
+      it('generate week array', () => {
+        const weeks = adapter.getWeekArray(dateTime);
+        expect(weeks[0].map((d) => d.toISO())).toEqual([
+          '2019-12-29T00:00:00.000Z',
+          '2019-12-30T00:00:00.000Z',
+          '2019-12-31T00:00:00.000Z',
+          '2020-01-01T00:00:00.000Z',
+          '2020-01-02T00:00:00.000Z',
+          '2020-01-03T00:00:00.000Z',
+          '2020-01-04T00:00:00.000Z',
+        ]);
+
+        expect(weeks[weeks.length - 1].map((d) => d.toISO())).toEqual([
+          '2020-01-26T00:00:00.000Z',
+          '2020-01-27T00:00:00.000Z',
+          '2020-01-28T00:00:00.000Z',
+          '2020-01-29T00:00:00.000Z',
+          '2020-01-30T00:00:00.000Z',
+          '2020-01-31T00:00:00.000Z',
+          '2020-02-01T00:00:00.000Z',
+        ]);
+      });
+    });
+
+    describe('for the month with 1st day been Sunday', () => {
+      const dateTime = DateTime.fromISO('2020-03-05T00:00:00Z');
+
+      it('generate week array', () => {
+        const weeks = adapter.getWeekArray(dateTime);
+        expect(weeks[0].map((d) => d.toISO())).toEqual([
+          '2020-03-01T00:00:00.000Z',
+          '2020-03-02T00:00:00.000Z',
+          '2020-03-03T00:00:00.000Z',
+          '2020-03-04T00:00:00.000Z',
+          '2020-03-05T00:00:00.000Z',
+          '2020-03-06T00:00:00.000Z',
+          '2020-03-07T00:00:00.000Z',
+        ]);
+
+        expect(weeks[weeks.length - 1].map((d) => d.toISO())).toEqual([
+          '2020-03-29T00:00:00.000Z',
+          '2020-03-30T00:00:00.000Z',
+          '2020-03-31T00:00:00.000Z',
+          '2020-04-01T00:00:00.000Z',
+          '2020-04-02T00:00:00.000Z',
+          '2020-04-03T00:00:00.000Z',
+          '2020-04-04T00:00:00.000Z',
+        ]);
+      });
+    });
+
+    describe('for the month with last day been Saturday', () => {
+      const dateTime = DateTime.fromISO('2020-02-05T00:00:00Z');
+
+      it('generate week array', () => {
+        const weeks = adapter.getWeekArray(dateTime);
+
+        expect(weeks[weeks.length - 1].map((d) => d.toISO())).toEqual([
+          '2020-02-23T00:00:00.000Z',
+          '2020-02-24T00:00:00.000Z',
+          '2020-02-25T00:00:00.000Z',
+          '2020-02-26T00:00:00.000Z',
+          '2020-02-27T00:00:00.000Z',
+          '2020-02-28T00:00:00.000Z',
+          '2020-02-29T00:00:00.000Z',
+        ]);
+      });
+    });
+  });
+
+  describe('for de locale', () => {
+    beforeEach(() => {
+      setLocale('de');
+    });
+
+    it('generate weekdays', () => {
+      expect(adapter.getWeekdays()).toEqual([
+        'M',
+        'D',
+        'M',
+        'D',
+        'F',
+        'S',
+        'S',
+      ]);
+    });
+
+    describe('for the month', () => {
+      const dateTime = DateTime.fromISO('2020-01-05T00:00:00Z');
+
+      it('week array should start on Monday', () => {
+        const weeks = adapter.getWeekArray(dateTime);
+        expect(weeks[0][0].weekday).toEqual(1);
+      });
+
+      it('generate week array', () => {
+        const weeks = adapter.getWeekArray(dateTime);
+        expect(weeks[0].map((d) => d.toISO())).toEqual([
+          '2019-12-30T00:00:00.000Z',
+          '2019-12-31T00:00:00.000Z',
+          '2020-01-01T00:00:00.000Z',
+          '2020-01-02T00:00:00.000Z',
+          '2020-01-03T00:00:00.000Z',
+          '2020-01-04T00:00:00.000Z',
+          '2020-01-05T00:00:00.000Z',
+        ]);
+
+        expect(weeks[weeks.length - 1].map((d) => d.toISO())).toEqual([
+          '2020-01-27T00:00:00.000Z',
+          '2020-01-28T00:00:00.000Z',
+          '2020-01-29T00:00:00.000Z',
+          '2020-01-30T00:00:00.000Z',
+          '2020-01-31T00:00:00.000Z',
+          '2020-02-01T00:00:00.000Z',
+          '2020-02-02T00:00:00.000Z',
+        ]);
+      });
+    });
+
+    describe('for the month with 1st day been Monday', () => {
+      const dateTime = DateTime.fromISO('2020-06-05T00:00:00Z');
+
+      it('generate week array', () => {
+        const weeks = adapter.getWeekArray(dateTime);
+        expect(weeks[0].map((d) => d.toISO())).toEqual([
+          '2020-06-01T00:00:00.000Z',
+          '2020-06-02T00:00:00.000Z',
+          '2020-06-03T00:00:00.000Z',
+          '2020-06-04T00:00:00.000Z',
+          '2020-06-05T00:00:00.000Z',
+          '2020-06-06T00:00:00.000Z',
+          '2020-06-07T00:00:00.000Z',
+        ]);
+
+        expect(weeks[weeks.length - 1].map((d) => d.toISO())).toEqual([
+          '2020-06-29T00:00:00.000Z',
+          '2020-06-30T00:00:00.000Z',
+          '2020-07-01T00:00:00.000Z',
+          '2020-07-02T00:00:00.000Z',
+          '2020-07-03T00:00:00.000Z',
+          '2020-07-04T00:00:00.000Z',
+          '2020-07-05T00:00:00.000Z',
+        ]);
+      });
+    });
+
+    describe('for the month with last day been Sunday', () => {
+      const dateTime = DateTime.fromISO('2020-05-05T00:00:00Z');
+
+      it('generate week array', () => {
+        const weeks = adapter.getWeekArray(dateTime);
+
+        expect(weeks[weeks.length - 1].map((d) => d.toISO())).toEqual([
+          '2020-05-25T00:00:00.000Z',
+          '2020-05-26T00:00:00.000Z',
+          '2020-05-27T00:00:00.000Z',
+          '2020-05-28T00:00:00.000Z',
+          '2020-05-29T00:00:00.000Z',
+          '2020-05-30T00:00:00.000Z',
+          '2020-05-31T00:00:00.000Z',
+        ]);
+      });
+    });
+  });
+});

--- a/matrix-meetings-widget/src/components/common/AdapterLuxonWeekday.ts
+++ b/matrix-meetings-widget/src/components/common/AdapterLuxonWeekday.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
+import { DateTime } from 'luxon';
+import { generateFilterRange, localeWeekdays } from '../../lib/utils';
+
+/**
+ * Custom Luxon Adapter that generates weekdays starting from the day determined by locale.
+ */
+export class AdapterLuxonWeekday extends AdapterLuxon {
+  public getWeekdays = () => {
+    return localeWeekdays('narrow', true);
+  };
+
+  public getWeekArray = (value: DateTime) => {
+    // implementation is copied from MUI-X with small modifications: https://github.com/mui/mui-x/blob/e5e7374d8753a59000a52d3d0ceb55c9ad7784d2/packages/x-date-pickers/src/AdapterLuxon/AdapterLuxon.ts#L528
+    // and modified to use normalized start/end of week to support weeks starting from day other than Monday.
+    const cleanValue = value;
+
+    const expectedLocale = this.getCurrentLocaleCode();
+    if (expectedLocale !== value.locale) {
+      cleanValue.setLocale(expectedLocale);
+    }
+
+    const normStartOfMonth = DateTime.fromISO(
+      generateFilterRange('week', cleanValue.startOf('month').toISO()).startDate
+    );
+    const normEndOfMonth = DateTime.fromISO(
+      generateFilterRange('week', cleanValue.endOf('month').toISO()).endDate
+    );
+
+    const { days } = normEndOfMonth.diff(normStartOfMonth, 'days').toObject();
+
+    const weeks: DateTime[][] = [];
+    new Array<number>(Math.round(days!))
+      .fill(0)
+      .map((_, i) => i)
+      .map((day) => normStartOfMonth.plus({ days: day }))
+      .forEach((v, i) => {
+        if (i === 0 || (i % 7 === 0 && i > 6)) {
+          weeks.push([v]);
+          return;
+        }
+
+        weeks[weeks.length - 1].push(v);
+      });
+
+    return weeks;
+  };
+}

--- a/matrix-meetings-widget/src/components/common/DateTimePickers/ButtonDatePicker.test.tsx
+++ b/matrix-meetings-widget/src/components/common/DateTimePickers/ButtonDatePicker.test.tsx
@@ -17,7 +17,7 @@
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import { ComponentType, PropsWithChildren, useState } from 'react';
 import { LocalizationProvider } from '../LocalizationProvider';
 import { ButtonDatePicker } from './ButtonDatePicker';
@@ -38,7 +38,7 @@ function Component() {
       onOpen={() => setOpen(true)}
       open={open}
       reduceAnimations
-      value={moment('2022-02-07T00:00:00Z')}
+      value={DateTime.fromISO('2022-02-07T00:00:00Z')}
       label="Choose date"
     />
   );

--- a/matrix-meetings-widget/src/components/common/DateTimePickers/ButtonDatePicker.tsx
+++ b/matrix-meetings-widget/src/components/common/DateTimePickers/ButtonDatePicker.tsx
@@ -23,12 +23,12 @@ import {
   DatePickerProps,
   FieldSection,
 } from '@mui/x-date-pickers';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import { DispatchWithoutAction } from 'react';
 
 type ButtonFieldProps = BaseSingleInputFieldProps<
-  moment.Moment | null,
-  moment.Moment,
+  DateTime | null,
+  DateTime,
   FieldSection,
   unknown
 > & {
@@ -66,7 +66,7 @@ function ButtonField(props: ButtonFieldProps) {
   );
 }
 
-export function ButtonDatePicker(props: DatePickerProps<moment.Moment>) {
+export function ButtonDatePicker(props: DatePickerProps<DateTime>) {
   const { open, onClose, onOpen } = props;
   return (
     <DatePicker

--- a/matrix-meetings-widget/src/components/common/DateTimePickers/CalendarDayPicker.tsx
+++ b/matrix-meetings-widget/src/components/common/DateTimePickers/CalendarDayPicker.tsx
@@ -42,7 +42,7 @@ export const CalendarDayPicker = ({
   const onOpen = useCallback(() => setOpen(true), []);
   const onClose = useCallback(() => setOpen(false), []);
 
-  const startMoment = useMemo(() => DateTime.fromISO(startDate), [startDate]);
+  const start = useMemo(() => DateTime.fromISO(startDate), [startDate]);
 
   const handleRangeChange = useCallback(
     (value: DateTime | null) => {
@@ -93,7 +93,7 @@ export const CalendarDayPicker = ({
       sx={sx}
       reduceAnimations={isReduceAnimations()}
       showDaysOutsideCurrentMonth
-      value={startMoment}
+      value={start}
       views={['year', 'month', 'day']}
       label={t('calendarDayPicker.label', '{{date, datetime}}', {
         date: new Date(startDate),

--- a/matrix-meetings-widget/src/components/common/DateTimePickers/CalendarDayPicker.tsx
+++ b/matrix-meetings-widget/src/components/common/DateTimePickers/CalendarDayPicker.tsx
@@ -15,7 +15,7 @@
  */
 
 import { SxProps } from '@mui/material';
-import moment, { Moment } from 'moment';
+import { DateTime } from 'luxon';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { generateFilterRange } from '../../../lib/utils';
@@ -42,12 +42,12 @@ export const CalendarDayPicker = ({
   const onOpen = useCallback(() => setOpen(true), []);
   const onClose = useCallback(() => setOpen(false), []);
 
-  const startMoment = useMemo(() => moment(startDate), [startDate]);
+  const startMoment = useMemo(() => DateTime.fromISO(startDate), [startDate]);
 
   const handleRangeChange = useCallback(
-    (value: Moment | null) => {
-      if (value?.isValid()) {
-        const date = value.toISOString();
+    (value: DateTime | null) => {
+      if (value?.isValid) {
+        const date = value.toISO();
         const { startDate, endDate } = generateFilterRange('day', date);
         onRangeChange(startDate, endDate);
       }

--- a/matrix-meetings-widget/src/components/common/DateTimePickers/CalendarMonthPicker.tsx
+++ b/matrix-meetings-widget/src/components/common/DateTimePickers/CalendarMonthPicker.tsx
@@ -42,7 +42,7 @@ export const CalendarMonthPicker = ({
   const onOpen = useCallback(() => setOpen(true), []);
   const onClose = useCallback(() => setOpen(false), []);
 
-  const startMoment = useMemo(() => DateTime.fromISO(startDate), [startDate]);
+  const start = useMemo(() => DateTime.fromISO(startDate), [startDate]);
 
   const handleRangeChange = useCallback(
     (value: DateTime | null) => {
@@ -94,7 +94,7 @@ export const CalendarMonthPicker = ({
       sx={sx}
       reduceAnimations={isReduceAnimations()}
       showDaysOutsideCurrentMonth
-      value={startMoment}
+      value={start}
       views={['year', 'month']}
       label={t('calendarMonthPicker.label', '{{date, datetime}}', {
         date: new Date(startDate),

--- a/matrix-meetings-widget/src/components/common/DateTimePickers/CalendarMonthPicker.tsx
+++ b/matrix-meetings-widget/src/components/common/DateTimePickers/CalendarMonthPicker.tsx
@@ -15,7 +15,7 @@
  */
 
 import { SxProps } from '@mui/material';
-import moment, { Moment } from 'moment';
+import { DateTime } from 'luxon';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { generateFilterRange } from '../../../lib/utils';
@@ -42,12 +42,12 @@ export const CalendarMonthPicker = ({
   const onOpen = useCallback(() => setOpen(true), []);
   const onClose = useCallback(() => setOpen(false), []);
 
-  const startMoment = useMemo(() => moment(startDate), [startDate]);
+  const startMoment = useMemo(() => DateTime.fromISO(startDate), [startDate]);
 
   const handleRangeChange = useCallback(
-    (value: Moment | null) => {
-      if (value?.isValid()) {
-        const date = value.toISOString();
+    (value: DateTime | null) => {
+      if (value?.isValid) {
+        const date = value.toISO();
         const { startDate, endDate } = generateFilterRange('month', date);
         onRangeChange(startDate, endDate);
       }

--- a/matrix-meetings-widget/src/components/common/DateTimePickers/CalendarWeekPicker.tsx
+++ b/matrix-meetings-widget/src/components/common/DateTimePickers/CalendarWeekPicker.tsx
@@ -135,10 +135,7 @@ function Day(
   const isBetween =
     startMoment &&
     endMoment &&
-    Interval.fromDateTimes(
-      startMoment.plus({ millisecond: 1 }),
-      endMoment.startOf('day')
-    ).contains(day);
+    Interval.fromDateTimes(startMoment, endMoment.plus(1)).contains(day);
 
   return (
     <HighlightedPickersDay

--- a/matrix-meetings-widget/src/components/common/DateTimePickers/CalendarWeekPicker.tsx
+++ b/matrix-meetings-widget/src/components/common/DateTimePickers/CalendarWeekPicker.tsx
@@ -48,8 +48,8 @@ export const CalendarWeekPicker = ({
   const onOpen = useCallback(() => setOpen(true), []);
   const onClose = useCallback(() => setOpen(false), []);
 
-  const startMoment = useMemo(() => DateTime.fromISO(startDate), [startDate]);
-  const endMoment = useMemo(() => DateTime.fromISO(endDate), [endDate]);
+  const start = useMemo(() => DateTime.fromISO(startDate), [startDate]);
+  const end = useMemo(() => DateTime.fromISO(endDate), [endDate]);
 
   const handleRangeChange = useCallback(
     (value: DateTime | null) => {
@@ -96,11 +96,11 @@ export const CalendarWeekPicker = ({
           },
         },
         day: {
-          startMoment,
-          endMoment,
+          start,
+          end,
         } as DatePickerSlotsComponentsProps<DateTime>['day'] & {
-          startMoment?: DateTime;
-          endMoment?: DateTime;
+          start?: DateTime;
+          end?: DateTime;
         },
       }}
       onAccept={handleRangeChange}
@@ -110,7 +110,7 @@ export const CalendarWeekPicker = ({
       sx={sx}
       reduceAnimations={isReduceAnimations()}
       showDaysOutsideCurrentMonth
-      value={endMoment}
+      value={end}
       views={['year', 'month', 'day']}
       label={t('calendarWeekPicker.label', '{{range, daterange}}', {
         range: [new Date(startDate), new Date(endDate)],
@@ -124,18 +124,16 @@ export const CalendarWeekPicker = ({
 
 function Day(
   props: PickersDayProps<DateTime> & {
-    startMoment?: DateTime;
-    endMoment?: DateTime;
+    start?: DateTime;
+    end?: DateTime;
   }
 ) {
-  const { day, startMoment, endMoment, ...other } = props;
+  const { day, start, end, ...other } = props;
 
-  const isFirstDay = startMoment?.hasSame(day, 'day');
-  const isLastDay = endMoment?.hasSame(day, 'day');
+  const isFirstDay = start?.hasSame(day, 'day');
+  const isLastDay = end?.hasSame(day, 'day');
   const isBetween =
-    startMoment &&
-    endMoment &&
-    Interval.fromDateTimes(startMoment, endMoment.plus(1)).contains(day);
+    start && end && Interval.fromDateTimes(start, end.plus(1)).contains(day);
 
   return (
     <HighlightedPickersDay

--- a/matrix-meetings-widget/src/components/common/DateTimePickers/CalendarWeekPicker.tsx
+++ b/matrix-meetings-widget/src/components/common/DateTimePickers/CalendarWeekPicker.tsx
@@ -19,7 +19,7 @@ import {
   DatePickerSlotsComponentsProps,
   PickersDayProps,
 } from '@mui/x-date-pickers';
-import moment, { Moment } from 'moment';
+import { DateTime, Interval } from 'luxon';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { generateFilterRange } from '../../../lib/utils';
@@ -48,13 +48,13 @@ export const CalendarWeekPicker = ({
   const onOpen = useCallback(() => setOpen(true), []);
   const onClose = useCallback(() => setOpen(false), []);
 
-  const startMoment = useMemo(() => moment(startDate), [startDate]);
-  const endMoment = useMemo(() => moment(endDate), [endDate]);
+  const startMoment = useMemo(() => DateTime.fromISO(startDate), [startDate]);
+  const endMoment = useMemo(() => DateTime.fromISO(endDate), [endDate]);
 
   const handleRangeChange = useCallback(
-    (value: Moment | null) => {
-      if (value?.isValid()) {
-        const date = value.toISOString();
+    (value: DateTime | null) => {
+      if (value?.isValid) {
+        const date = value.toISO();
         const { startDate, endDate } = generateFilterRange('week', date);
         onRangeChange(startDate, endDate);
         onClose();
@@ -98,9 +98,9 @@ export const CalendarWeekPicker = ({
         day: {
           startMoment,
           endMoment,
-        } as DatePickerSlotsComponentsProps<moment.Moment>['day'] & {
-          startMoment?: moment.Moment;
-          endMoment?: moment.Moment;
+        } as DatePickerSlotsComponentsProps<DateTime>['day'] & {
+          startMoment?: DateTime;
+          endMoment?: DateTime;
         },
       }}
       onAccept={handleRangeChange}
@@ -123,16 +123,22 @@ export const CalendarWeekPicker = ({
 };
 
 function Day(
-  props: PickersDayProps<moment.Moment> & {
-    startMoment?: moment.Moment;
-    endMoment?: moment.Moment;
+  props: PickersDayProps<DateTime> & {
+    startMoment?: DateTime;
+    endMoment?: DateTime;
   }
 ) {
   const { day, startMoment, endMoment, ...other } = props;
 
-  const isFirstDay = startMoment?.isSame(day, 'day');
-  const isLastDay = endMoment?.isSame(day, 'day');
-  const isBetween = day.isBetween(startMoment, endMoment, 'day');
+  const isFirstDay = startMoment?.hasSame(day, 'day');
+  const isLastDay = endMoment?.hasSame(day, 'day');
+  const isBetween =
+    startMoment &&
+    endMoment &&
+    Interval.fromDateTimes(
+      startMoment.plus({ millisecond: 1 }),
+      endMoment.startOf('day')
+    ).contains(day);
 
   return (
     <HighlightedPickersDay

--- a/matrix-meetings-widget/src/components/common/DateTimePickers/CalendarWorkWeekPicker.tsx
+++ b/matrix-meetings-widget/src/components/common/DateTimePickers/CalendarWorkWeekPicker.tsx
@@ -48,8 +48,8 @@ export const CalendarWorkWeekPicker = ({
   const onOpen = useCallback(() => setOpen(true), []);
   const onClose = useCallback(() => setOpen(false), []);
 
-  const startMoment = useMemo(() => DateTime.fromISO(startDate), [startDate]);
-  const endMoment = useMemo(() => DateTime.fromISO(endDate), [endDate]);
+  const start = useMemo(() => DateTime.fromISO(startDate), [startDate]);
+  const end = useMemo(() => DateTime.fromISO(endDate), [endDate]);
 
   const handleRangeChange = useCallback(
     (value: DateTime | null) => {
@@ -95,11 +95,11 @@ export const CalendarWorkWeekPicker = ({
           },
         },
         day: {
-          startMoment,
-          endMoment,
+          start,
+          end,
         } as DatePickerSlotsComponentsProps<DateTime>['day'] & {
-          startMoment?: DateTime;
-          endMoment?: DateTime;
+          start?: DateTime;
+          end?: DateTime;
         },
       }}
       onAccept={handleRangeChange}
@@ -109,7 +109,7 @@ export const CalendarWorkWeekPicker = ({
       sx={sx}
       reduceAnimations={isReduceAnimations()}
       showDaysOutsideCurrentMonth
-      value={endMoment}
+      value={end}
       views={['year', 'month', 'day']}
       label={t('calendarWorkWeekPicker.label', '{{range, daterange}}', {
         range: [new Date(startDate), new Date(endDate)],
@@ -123,18 +123,16 @@ export const CalendarWorkWeekPicker = ({
 
 function Day(
   props: PickersDayProps<DateTime> & {
-    startMoment?: DateTime;
-    endMoment?: DateTime;
+    start?: DateTime;
+    end?: DateTime;
   }
 ) {
-  const { day, startMoment, endMoment, ...other } = props;
+  const { day, start, end, ...other } = props;
 
-  const isFirstDay = startMoment?.hasSame(day, 'day');
-  const isLastDay = endMoment?.hasSame(day, 'day');
+  const isFirstDay = start?.hasSame(day, 'day');
+  const isLastDay = end?.hasSame(day, 'day');
   const isBetween =
-    startMoment &&
-    endMoment &&
-    Interval.fromDateTimes(startMoment, endMoment.plus(1)).contains(day);
+    start && end && Interval.fromDateTimes(start, end.plus(1)).contains(day);
 
   return (
     <HighlightedPickersDay

--- a/matrix-meetings-widget/src/components/common/DateTimePickers/CalendarWorkWeekPicker.tsx
+++ b/matrix-meetings-widget/src/components/common/DateTimePickers/CalendarWorkWeekPicker.tsx
@@ -19,7 +19,7 @@ import {
   DatePickerSlotsComponentsProps,
   PickersDayProps,
 } from '@mui/x-date-pickers';
-import moment, { Moment } from 'moment';
+import { DateTime, Interval } from 'luxon';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { generateFilterRange } from '../../../lib/utils';
@@ -48,13 +48,13 @@ export const CalendarWorkWeekPicker = ({
   const onOpen = useCallback(() => setOpen(true), []);
   const onClose = useCallback(() => setOpen(false), []);
 
-  const startMoment = useMemo(() => moment(startDate), [startDate]);
-  const endMoment = useMemo(() => moment(endDate), [endDate]);
+  const startMoment = useMemo(() => DateTime.fromISO(startDate), [startDate]);
+  const endMoment = useMemo(() => DateTime.fromISO(endDate), [endDate]);
 
   const handleRangeChange = useCallback(
-    (value: Moment | null) => {
-      if (value?.isValid()) {
-        const date = value.toISOString();
+    (value: DateTime | null) => {
+      if (value?.isValid) {
+        const date = value.toISO();
         const { startDate, endDate } = generateFilterRange('workWeek', date);
         onRangeChange(startDate, endDate);
         onClose();
@@ -97,9 +97,9 @@ export const CalendarWorkWeekPicker = ({
         day: {
           startMoment,
           endMoment,
-        } as DatePickerSlotsComponentsProps<moment.Moment>['day'] & {
-          startMoment?: moment.Moment;
-          endMoment?: moment.Moment;
+        } as DatePickerSlotsComponentsProps<DateTime>['day'] & {
+          startMoment?: DateTime;
+          endMoment?: DateTime;
         },
       }}
       onAccept={handleRangeChange}
@@ -122,16 +122,22 @@ export const CalendarWorkWeekPicker = ({
 };
 
 function Day(
-  props: PickersDayProps<moment.Moment> & {
-    startMoment?: moment.Moment;
-    endMoment?: moment.Moment;
+  props: PickersDayProps<DateTime> & {
+    startMoment?: DateTime;
+    endMoment?: DateTime;
   }
 ) {
   const { day, startMoment, endMoment, ...other } = props;
 
-  const isFirstDay = startMoment?.isSame(day, 'day');
-  const isLastDay = endMoment?.isSame(day, 'day');
-  const isBetween = day.isBetween(startMoment, endMoment, 'day');
+  const isFirstDay = startMoment?.hasSame(day, 'day');
+  const isLastDay = endMoment?.hasSame(day, 'day');
+  const isBetween =
+    startMoment &&
+    endMoment &&
+    Interval.fromDateTimes(
+      startMoment.plus({ millisecond: 1 }),
+      endMoment.startOf('day')
+    ).contains(day);
 
   return (
     <HighlightedPickersDay

--- a/matrix-meetings-widget/src/components/common/DateTimePickers/CalendarWorkWeekPicker.tsx
+++ b/matrix-meetings-widget/src/components/common/DateTimePickers/CalendarWorkWeekPicker.tsx
@@ -134,10 +134,7 @@ function Day(
   const isBetween =
     startMoment &&
     endMoment &&
-    Interval.fromDateTimes(
-      startMoment.plus({ millisecond: 1 }),
-      endMoment.startOf('day')
-    ).contains(day);
+    Interval.fromDateTimes(startMoment, endMoment.plus(1)).contains(day);
 
   return (
     <HighlightedPickersDay

--- a/matrix-meetings-widget/src/components/common/DateTimePickers/DateRangePicker.tsx
+++ b/matrix-meetings-widget/src/components/common/DateTimePickers/DateRangePicker.tsx
@@ -158,8 +158,8 @@ function Day(
   const isBetween =
     !selectedStartDate &&
     Interval.fromDateTimes(
-      DateTime.fromISO(startDate).plus({ millisecond: 1 }),
-      DateTime.fromISO(endDate).startOf('day')
+      DateTime.fromISO(startDate),
+      DateTime.fromISO(endDate).plus(1)
     ).contains(day);
 
   return (

--- a/matrix-meetings-widget/src/components/common/DateTimePickers/EndDatePicker.test.tsx
+++ b/matrix-meetings-widget/src/components/common/DateTimePickers/EndDatePicker.test.tsx
@@ -17,7 +17,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
-import * as moment from 'moment-timezone';
+import { DateTime } from 'luxon';
 import { ComponentType, PropsWithChildren } from 'react';
 import { LocalizationProvider } from '../LocalizationProvider';
 import { EndDatePicker } from './EndDatePicker';
@@ -36,7 +36,7 @@ describe('<EndDatePicker/>', () => {
     render(
       <EndDatePicker
         onChange={onChange}
-        value={moment.utc('2020-01-01T12:15:38Z')}
+        value={DateTime.fromISO('2020-01-01T12:15:38Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -55,7 +55,7 @@ describe('<EndDatePicker/>', () => {
     const { container } = render(
       <EndDatePicker
         onChange={onChange}
-        value={moment.utc('2020-01-01T12:15:38Z')}
+        value={DateTime.fromISO('2020-01-01T12:15:38Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -67,7 +67,7 @@ describe('<EndDatePicker/>', () => {
     const { container } = render(
       <EndDatePicker
         onChange={onChange}
-        value={moment.utc('2020-01-01T12:15:38Z')}
+        value={DateTime.fromISO('2020-01-01T12:15:38Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -85,7 +85,7 @@ describe('<EndDatePicker/>', () => {
     render(
       <EndDatePicker
         onChange={onChange}
-        value={moment.utc('2020-01-01T12:15:38.123Z')}
+        value={DateTime.fromISO('2020-01-01T12:15:38.123Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -96,15 +96,18 @@ describe('<EndDatePicker/>', () => {
     });
 
     expect(onChange).toBeCalled();
-    expect(onChange.mock.calls[0][0].toISOString()).toEqual(
+    expect(onChange.mock.calls[0][0].toISO()).toEqual(
       '2022-06-05T12:15:00.000Z'
     );
   });
 
   it('should not update on invalid value', () => {
-    render(<EndDatePicker onChange={onChange} value={moment.invalid()} />, {
-      wrapper: Wrapper,
-    });
+    render(
+      <EndDatePicker onChange={onChange} value={DateTime.invalid('Invalid')} />,
+      {
+        wrapper: Wrapper,
+      }
+    );
 
     const textbox = screen.getByRole('textbox', {
       name: /end date/i,
@@ -126,7 +129,7 @@ describe('<EndDatePicker/>', () => {
       <EndDatePicker
         error="This is wrong"
         onChange={onChange}
-        value={moment.utc('2020-01-01T12:15:38Z')}
+        value={DateTime.fromISO('2020-01-01T12:15:38Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -141,7 +144,7 @@ describe('<EndDatePicker/>', () => {
     const { rerender } = render(
       <EndDatePicker
         onChange={onChange}
-        value={moment.utc('2020-01-01T12:15:38.123Z')}
+        value={DateTime.fromISO('2020-01-01T12:15:38.123Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -153,7 +156,7 @@ describe('<EndDatePicker/>', () => {
     rerender(
       <EndDatePicker
         onChange={onChange}
-        value={moment.utc('2021-01-01T12:15:38.123Z')}
+        value={DateTime.fromISO('2021-01-01T12:15:38.123Z')}
       />
     );
 
@@ -164,7 +167,7 @@ describe('<EndDatePicker/>', () => {
     render(
       <EndDatePicker
         onChange={onChange}
-        value={moment.utc('2020-01-01T12:15:38.123Z')}
+        value={DateTime.fromISO('2020-01-01T12:15:38.123Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -178,7 +181,7 @@ describe('<EndDatePicker/>', () => {
       <EndDatePicker
         enablePast
         onChange={onChange}
-        value={moment.utc('2020-01-01T12:15:38.123Z')}
+        value={DateTime.fromISO('2020-01-01T12:15:38.123Z')}
       />,
       { wrapper: Wrapper }
     );

--- a/matrix-meetings-widget/src/components/common/DateTimePickers/EndDatePicker.tsx
+++ b/matrix-meetings-widget/src/components/common/DateTimePickers/EndDatePicker.tsx
@@ -15,17 +15,17 @@
  */
 
 import { DatePicker } from '@mui/x-date-pickers';
-import moment, { Moment } from 'moment';
+import { DateTime } from 'luxon';
 import { Dispatch, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { longDateFormat } from './dateFormat';
 import { isReduceAnimations } from './helper';
 
 type EndDatePickerProps = {
-  value: Moment;
+  value: DateTime;
   error?: boolean | string;
   enablePast?: boolean;
-  onChange: Dispatch<Moment>;
+  onChange: Dispatch<DateTime>;
 };
 
 export function EndDatePicker({
@@ -42,12 +42,12 @@ export function EndDatePicker({
   }, [value]);
 
   const openDatePickerDialogue = useCallback(
-    (date: Moment | null) => {
+    (date: DateTime | null) => {
       return t(
         'dateTimePickers.openEndDatePicker',
         'Choose end date, selected date is {{date, datetime}}',
         {
-          date: date?.toDate(),
+          date: date?.toJSDate(),
           formatParams: {
             date: longDateFormat,
           },
@@ -58,17 +58,14 @@ export function EndDatePicker({
   );
 
   const handleOnChange = useCallback(
-    (date: Moment | null) => {
-      // It is necessary to clone the moment object
-      // (https://github.com/mui/material-ui-pickers/issues/359#issuecomment-381566442)
-      const newValue = moment(date?.toDate())
-        .hours(value.hours())
-        .minutes(value.minutes())
+    (date: DateTime | null) => {
+      const newValue = (date ?? DateTime.now())
+        .set({ hour: value.hour, minute: value.minute })
         .startOf('minute');
 
       setDate(newValue);
 
-      if (date?.isValid()) {
+      if (date?.isValid) {
         onChange(newValue);
       }
     },
@@ -88,11 +85,11 @@ export function EndDatePicker({
         textField: {
           fullWidth: true,
           helperText:
-            (!date.isValid() &&
+            (!date.isValid &&
               t('dateTimePickers.invalidEndDate', 'Invalid date')) ||
             (typeof error === 'string' ? error : undefined),
           margin: 'dense',
-          error: !date.isValid() || !!error || undefined,
+          error: !date.isValid || !!error || undefined,
         },
       }}
       value={date}

--- a/matrix-meetings-widget/src/components/common/DateTimePickers/EndTimePicker.test.tsx
+++ b/matrix-meetings-widget/src/components/common/DateTimePickers/EndTimePicker.test.tsx
@@ -17,7 +17,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
-import * as moment from 'moment-timezone';
+import { DateTime } from 'luxon';
 import { ComponentType, PropsWithChildren } from 'react';
 import { LocalizationProvider } from '../LocalizationProvider';
 import { EndTimePicker } from './EndTimePicker';
@@ -36,7 +36,7 @@ describe('<EndTimePicker/>', () => {
     render(
       <EndTimePicker
         onChange={onChange}
-        value={moment.utc('2020-01-01T12:15:38Z')}
+        value={DateTime.fromISO('2020-01-01T12:15:38Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -55,7 +55,7 @@ describe('<EndTimePicker/>', () => {
     const { container } = render(
       <EndTimePicker
         onChange={onChange}
-        value={moment.utc('2020-01-01T12:15:38Z')}
+        value={DateTime.fromISO('2020-01-01T12:15:38Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -67,7 +67,7 @@ describe('<EndTimePicker/>', () => {
     const { container } = render(
       <EndTimePicker
         onChange={onChange}
-        value={moment.utc('2020-01-01T12:15:38Z')}
+        value={DateTime.fromISO('2020-01-01T12:15:38Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -81,7 +81,7 @@ describe('<EndTimePicker/>', () => {
     render(
       <EndTimePicker
         onChange={onChange}
-        value={moment.utc('2020-01-01T12:15:38.123Z')}
+        value={DateTime.fromISO('2020-01-01T12:15:38.123Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -92,15 +92,18 @@ describe('<EndTimePicker/>', () => {
     });
 
     expect(onChange).toBeCalled();
-    expect(onChange.mock.calls[0][0].toISOString()).toEqual(
+    expect(onChange.mock.calls[0][0].toISO()).toEqual(
       '2020-01-01T08:15:00.000Z'
     );
   });
 
   it('should not update on invalid value', () => {
-    render(<EndTimePicker onChange={onChange} value={moment.invalid()} />, {
-      wrapper: Wrapper,
-    });
+    render(
+      <EndTimePicker onChange={onChange} value={DateTime.invalid('Invalid')} />,
+      {
+        wrapper: Wrapper,
+      }
+    );
 
     const textbox = screen.getByRole('textbox', {
       name: /end time/i,
@@ -122,7 +125,7 @@ describe('<EndTimePicker/>', () => {
       <EndTimePicker
         error="This is wrong"
         onChange={onChange}
-        value={moment.utc('2020-01-01T12:15:38Z')}
+        value={DateTime.fromISO('2020-01-01T12:15:38Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -136,7 +139,7 @@ describe('<EndTimePicker/>', () => {
     const { rerender } = render(
       <EndTimePicker
         onChange={onChange}
-        value={moment.utc('2020-01-01T12:15:38.123Z')}
+        value={DateTime.fromISO('2020-01-01T12:15:38.123Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -148,7 +151,7 @@ describe('<EndTimePicker/>', () => {
     rerender(
       <EndTimePicker
         onChange={onChange}
-        value={moment.utc('2020-01-01T14:15:38.123Z')}
+        value={DateTime.fromISO('2020-01-01T14:15:38.123Z')}
       />
     );
 

--- a/matrix-meetings-widget/src/components/common/DateTimePickers/EndTimePicker.tsx
+++ b/matrix-meetings-widget/src/components/common/DateTimePickers/EndTimePicker.tsx
@@ -64,10 +64,7 @@ export function EndTimePicker({
 
   const handleOnChange = useCallback(
     (date: DateTime | null) => {
-      const newValue = (date ?? DateTime.now()).set({
-        second: 0,
-        millisecond: 0,
-      });
+      const newValue = (date ?? DateTime.now()).startOf('minute');
 
       setDate(newValue);
 

--- a/matrix-meetings-widget/src/components/common/DateTimePickers/EndTimePicker.tsx
+++ b/matrix-meetings-widget/src/components/common/DateTimePickers/EndTimePicker.tsx
@@ -17,16 +17,16 @@
 import { TextFieldProps } from '@mui/material';
 import { visuallyHidden } from '@mui/utils';
 import { TimePicker } from '@mui/x-date-pickers';
-import moment, { Moment } from 'moment';
+import { DateTime } from 'luxon';
 import { Dispatch, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { timeOnlyDateFormat } from './dateFormat';
 
 type EndTimePickerProps = {
-  value: Moment;
+  value: DateTime;
   error?: boolean | string;
   hideHelperText?: boolean;
-  onChange: Dispatch<Moment>;
+  onChange: Dispatch<DateTime>;
   TextFieldProps?: Partial<TextFieldProps>;
 };
 
@@ -44,15 +44,15 @@ export function EndTimePicker({
     setDate(value);
   }, [value]);
 
-  const invalidDate = !date.isValid();
+  const invalidDate = !date.isValid;
 
   const openDatePickerDialogue = useCallback(
-    (date: Moment | null) => {
+    (date: DateTime | null) => {
       return t(
         'dateTimePickers.openEndTimePicker',
         'Choose end time, selected time is  {{date, datetime}}',
         {
-          date: date?.toDate(),
+          date: date?.toJSDate(),
           formatParams: {
             date: timeOnlyDateFormat,
           },
@@ -63,14 +63,15 @@ export function EndTimePicker({
   );
 
   const handleOnChange = useCallback(
-    (date: Moment | null) => {
-      // It is necessary to clone the moment object
-      // (https://github.com/mui/material-ui-pickers/issues/359#issuecomment-381566442)
-      const newValue = moment(date?.toDate()).seconds(0).milliseconds(0);
+    (date: DateTime | null) => {
+      const newValue = (date ?? DateTime.now()).set({
+        second: 0,
+        millisecond: 0,
+      });
 
       setDate(newValue);
 
-      if (date?.isValid()) {
+      if (date?.isValid) {
         onChange(newValue);
       }
     },

--- a/matrix-meetings-widget/src/components/common/DateTimePickers/HighlightedPickersDay.tsx
+++ b/matrix-meetings-widget/src/components/common/DateTimePickers/HighlightedPickersDay.tsx
@@ -23,43 +23,37 @@ export function HighlightedPickersDay({
   isLastDay,
   ...pickersDayProps
 }: PickersDayProps<DateTime> & {
-  isFirstDay?: boolean;
-  isBetween?: boolean;
-  isLastDay?: boolean;
+  /** If true, the selected date is part of the selection. */
+  isBetween: boolean | undefined;
+  /** If true, the selected date is the first day of the selection. */
+  isFirstDay: boolean | undefined;
+  /** If true, the selected date is the last day of the selection. */
+  isLastDay: boolean | undefined;
 }) {
   return (
     <PickersDay
       sx={{
-        ...(isFirstDay || isBetween || isLastDay ? { px: 2.5, mx: 0 } : {}),
+        ...(isBetween && {
+          px: 2.5,
+          mx: 0,
+          borderColor: 'primary.main',
+          borderRadius: 0,
+          borderWidth: 1,
+          borderTopStyle: 'solid',
+          borderBottomStyle: 'solid',
+        }),
         ...(isFirstDay &&
           !isLastDay && {
-            borderTopRightRadius: 0,
-            borderBottomRightRadius: 0,
-            borderColor: 'primary.main',
-            borderTopStyle: 'solid',
+            borderTopLeftRadius: '50%',
+            borderBottomLeftRadius: '50%',
             borderLeftStyle: 'solid',
-            borderBottomStyle: 'solid',
-            borderWidth: 1,
           }),
         ...(isLastDay &&
           !isFirstDay && {
-            borderTopLeftRadius: 0,
-            borderBottomLeftRadius: 0,
-            borderColor: 'primary.main',
-            borderTopStyle: 'solid',
+            borderTopRightRadius: '50%',
+            borderBottomRightRadius: '50%',
             borderRightStyle: 'solid',
-            borderBottomStyle: 'solid',
-            borderWidth: 1,
           }),
-        ...(isBetween && {
-          borderTopColor: 'primary.main',
-          borderBottomColor: 'primary.main',
-          borderRadius: 0,
-          borderTopStyle: 'solid',
-          borderBottomStyle: 'solid',
-          borderTopWidth: 1,
-          borderBottomWidth: 1,
-        }),
       }}
       {...pickersDayProps}
       selected={isFirstDay || isLastDay}

--- a/matrix-meetings-widget/src/components/common/DateTimePickers/HighlightedPickersDay.tsx
+++ b/matrix-meetings-widget/src/components/common/DateTimePickers/HighlightedPickersDay.tsx
@@ -15,14 +15,14 @@
  */
 
 import { PickersDay, PickersDayProps } from '@mui/x-date-pickers';
-import { Moment } from 'moment';
+import { DateTime } from 'luxon';
 
 export function HighlightedPickersDay({
   isFirstDay,
   isBetween,
   isLastDay,
   ...pickersDayProps
-}: PickersDayProps<Moment> & {
+}: PickersDayProps<DateTime> & {
   isFirstDay?: boolean;
   isBetween?: boolean;
   isLastDay?: boolean;

--- a/matrix-meetings-widget/src/components/common/DateTimePickers/StartDatePicker.test.tsx
+++ b/matrix-meetings-widget/src/components/common/DateTimePickers/StartDatePicker.test.tsx
@@ -17,7 +17,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
-import * as moment from 'moment-timezone';
+import { DateTime } from 'luxon';
 import { ComponentType, PropsWithChildren } from 'react';
 import { LocalizationProvider } from '../LocalizationProvider';
 import { StartDatePicker } from './StartDatePicker';
@@ -36,7 +36,7 @@ describe('<StartDatePicker/>', () => {
     render(
       <StartDatePicker
         onChange={onChange}
-        value={moment.utc('2020-01-01T12:15:38Z')}
+        value={DateTime.fromISO('2020-01-01T12:15:38Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -55,7 +55,7 @@ describe('<StartDatePicker/>', () => {
     const { container } = render(
       <StartDatePicker
         onChange={onChange}
-        value={moment.utc('2020-01-01T12:15:38Z')}
+        value={DateTime.fromISO('2020-01-01T12:15:38Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -67,7 +67,7 @@ describe('<StartDatePicker/>', () => {
     const { container } = render(
       <StartDatePicker
         onChange={onChange}
-        value={moment.utc('2020-01-01T12:15:38Z')}
+        value={DateTime.fromISO('2020-01-01T12:15:38Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -81,7 +81,7 @@ describe('<StartDatePicker/>', () => {
     render(
       <StartDatePicker
         onChange={onChange}
-        value={moment.utc('2020-01-01T12:15:38.123Z')}
+        value={DateTime.fromISO('2020-01-01T12:15:38.123Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -92,15 +92,21 @@ describe('<StartDatePicker/>', () => {
     });
 
     expect(onChange).toBeCalled();
-    expect(onChange.mock.calls[0][0].toISOString()).toEqual(
+    expect(onChange.mock.calls[0][0].toISO()).toEqual(
       '2022-06-05T12:15:00.000Z'
     );
   });
 
   it('should not update on invalid value', () => {
-    render(<StartDatePicker onChange={onChange} value={moment.invalid()} />, {
-      wrapper: Wrapper,
-    });
+    render(
+      <StartDatePicker
+        onChange={onChange}
+        value={DateTime.invalid('Invalid')}
+      />,
+      {
+        wrapper: Wrapper,
+      }
+    );
 
     const textbox = screen.getByRole('textbox', {
       name: /start date/i,
@@ -122,7 +128,7 @@ describe('<StartDatePicker/>', () => {
       <StartDatePicker
         error="This is wrong"
         onChange={onChange}
-        value={moment.utc('2020-01-01T12:15:38Z')}
+        value={DateTime.fromISO('2020-01-01T12:15:38Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -141,7 +147,7 @@ describe('<StartDatePicker/>', () => {
         error="This is wrong"
         onChange={onChange}
         readOnly="This is readonly"
-        value={moment.utc('2020-01-01T12:15:38Z')}
+        value={DateTime.fromISO('2020-01-01T12:15:38Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -159,7 +165,7 @@ describe('<StartDatePicker/>', () => {
     const { rerender } = render(
       <StartDatePicker
         onChange={onChange}
-        value={moment.utc('2020-01-01T12:15:38.123Z')}
+        value={DateTime.fromISO('2020-01-01T12:15:38.123Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -171,7 +177,7 @@ describe('<StartDatePicker/>', () => {
     rerender(
       <StartDatePicker
         onChange={onChange}
-        value={moment.utc('2021-01-01T12:15:38.123Z')}
+        value={DateTime.fromISO('2021-01-01T12:15:38.123Z')}
       />
     );
 
@@ -181,9 +187,9 @@ describe('<StartDatePicker/>', () => {
   it('disallow values in the past (before min date)', () => {
     render(
       <StartDatePicker
-        minDate={moment.utc('2020-01-02T12:15:38Z')}
+        minDate={DateTime.fromISO('2020-01-02T12:15:38Z')}
         onChange={onChange}
-        value={moment.utc('2020-01-01T12:15:38Z')}
+        value={DateTime.fromISO('2020-01-01T12:15:38Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -196,9 +202,9 @@ describe('<StartDatePicker/>', () => {
   it('allow values in the past (after min date)', () => {
     render(
       <StartDatePicker
-        minDate={moment.utc('2020-01-01T12:15:38Z')}
+        minDate={DateTime.fromISO('2020-01-01T12:15:38Z')}
         onChange={onChange}
-        value={moment.utc('2020-02-01T12:17:38Z')}
+        value={DateTime.fromISO('2020-02-01T12:17:38Z')}
       />,
       { wrapper: Wrapper }
     );

--- a/matrix-meetings-widget/src/components/common/DateTimePickers/StartDatePicker.tsx
+++ b/matrix-meetings-widget/src/components/common/DateTimePickers/StartDatePicker.tsx
@@ -16,15 +16,15 @@
 
 import { TextFieldProps } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers';
-import moment, { Moment } from 'moment';
+import { DateTime } from 'luxon';
 import { Dispatch, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { longDateFormat } from './dateFormat';
 import { isReduceAnimations } from './helper';
 
 type StartDatePickerProps = {
-  value: Moment;
-  onChange: Dispatch<Moment>;
+  value: DateTime;
+  onChange: Dispatch<DateTime>;
   TextFieldProps?: Partial<TextFieldProps>;
 
   /**
@@ -41,7 +41,7 @@ type StartDatePickerProps = {
    */
   readOnly?: string;
 
-  minDate?: Moment;
+  minDate?: DateTime;
 };
 
 export function StartDatePicker({
@@ -53,19 +53,19 @@ export function StartDatePicker({
   minDate,
 }: StartDatePickerProps) {
   const { t } = useTranslation();
-  const [date, setDate] = useState(value);
+  const [date, setDate] = useState<DateTime>(value);
 
   useEffect(() => {
     setDate(value);
   }, [value]);
 
   const openDatePickerDialogue = useCallback(
-    (date: Moment | null) => {
+    (date: DateTime | null) => {
       return t(
         'dateTimePickers.openStartDatePicker',
         'Choose start date, selected date is {{date, datetime}}',
         {
-          date: date?.toDate(),
+          date: date?.toJSDate(),
           formatParams: {
             date: longDateFormat,
           },
@@ -75,20 +75,17 @@ export function StartDatePicker({
     [t]
   );
 
-  const invalidDate = !date.isValid();
+  const invalidDate = !date.isValid;
 
   const handleOnChange = useCallback(
-    (date: Moment | null) => {
-      // It is necessary to clone the moment object
-      // (https://github.com/mui/material-ui-pickers/issues/359#issuecomment-381566442)
-      const newValue = moment(date?.toDate())
-        .hours(value.hours())
-        .minutes(value.minutes())
+    (date: DateTime | null) => {
+      const newValue = (date ?? DateTime.now())
+        .set({ hour: value.hour, minute: value.minute })
         .startOf('minute');
 
       setDate(newValue);
 
-      if (date?.isValid()) {
+      if (date?.isValid) {
         onChange(newValue);
       }
     },

--- a/matrix-meetings-widget/src/components/common/DateTimePickers/StartTimePicker.test.tsx
+++ b/matrix-meetings-widget/src/components/common/DateTimePickers/StartTimePicker.test.tsx
@@ -17,7 +17,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
-import * as moment from 'moment-timezone';
+import { DateTime } from 'luxon';
 import { ComponentType, PropsWithChildren } from 'react';
 import { LocalizationProvider } from '../LocalizationProvider';
 import { StartTimePicker } from './StartTimePicker';
@@ -36,7 +36,7 @@ describe('<StartTimePicker/>', () => {
     render(
       <StartTimePicker
         onChange={onChange}
-        value={moment.utc('2020-01-01T12:15:38Z')}
+        value={DateTime.fromISO('2020-01-01T12:15:38Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -55,7 +55,7 @@ describe('<StartTimePicker/>', () => {
     const { container } = render(
       <StartTimePicker
         onChange={onChange}
-        value={moment.utc('2020-01-01T12:15:38Z')}
+        value={DateTime.fromISO('2020-01-01T12:15:38Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -67,7 +67,7 @@ describe('<StartTimePicker/>', () => {
     const { container } = render(
       <StartTimePicker
         onChange={onChange}
-        value={moment.utc('2020-01-01T12:15:38Z')}
+        value={DateTime.fromISO('2020-01-01T12:15:38Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -81,7 +81,7 @@ describe('<StartTimePicker/>', () => {
     render(
       <StartTimePicker
         onChange={onChange}
-        value={moment.utc('2020-01-01T12:15:38.123Z')}
+        value={DateTime.fromISO('2020-01-01T12:15:38.123Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -92,15 +92,21 @@ describe('<StartTimePicker/>', () => {
     });
 
     expect(onChange).toBeCalled();
-    expect(onChange.mock.calls[0][0].toISOString()).toEqual(
+    expect(onChange.mock.calls[0][0].toISO()).toEqual(
       '2020-01-01T08:15:00.000Z'
     );
   });
 
   it('should not update on invalid value', () => {
-    render(<StartTimePicker onChange={onChange} value={moment.invalid()} />, {
-      wrapper: Wrapper,
-    });
+    render(
+      <StartTimePicker
+        onChange={onChange}
+        value={DateTime.invalid('Invalid')}
+      />,
+      {
+        wrapper: Wrapper,
+      }
+    );
 
     const textbox = screen.getByRole('textbox', {
       name: /start time/i,
@@ -122,7 +128,7 @@ describe('<StartTimePicker/>', () => {
       <StartTimePicker
         error="This is wrong"
         onChange={onChange}
-        value={moment.utc('2020-01-01T12:15:38Z')}
+        value={DateTime.fromISO('2020-01-01T12:15:38Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -140,7 +146,7 @@ describe('<StartTimePicker/>', () => {
         error="This is wrong"
         onChange={onChange}
         readOnly="This is readonly"
-        value={moment.utc('2020-01-01T12:15:38Z')}
+        value={DateTime.fromISO('2020-01-01T12:15:38Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -158,7 +164,7 @@ describe('<StartTimePicker/>', () => {
     const { rerender } = render(
       <StartTimePicker
         onChange={onChange}
-        value={moment.utc('2020-01-01T12:15:38.123Z')}
+        value={DateTime.fromISO('2020-01-01T12:15:38.123Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -170,7 +176,7 @@ describe('<StartTimePicker/>', () => {
     rerender(
       <StartTimePicker
         onChange={onChange}
-        value={moment.utc('2020-01-01T14:15:38.123Z')}
+        value={DateTime.fromISO('2020-01-01T14:15:38.123Z')}
       />
     );
 

--- a/matrix-meetings-widget/src/components/common/DateTimePickers/StartTimePicker.tsx
+++ b/matrix-meetings-widget/src/components/common/DateTimePickers/StartTimePicker.tsx
@@ -17,14 +17,14 @@
 import { TextFieldProps } from '@mui/material';
 import { visuallyHidden } from '@mui/utils';
 import { TimePicker } from '@mui/x-date-pickers';
-import moment, { Moment } from 'moment';
+import { DateTime } from 'luxon';
 import { Dispatch, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { timeOnlyDateFormat } from './dateFormat';
 
 type StartTimePickerProps = {
-  value: Moment;
-  onChange: Dispatch<Moment>;
+  value: DateTime;
+  onChange: Dispatch<DateTime>;
   TextFieldProps?: Partial<TextFieldProps>;
 
   /** If true, all helper texts are hidden. This affects both `error` and `readOnly`. */
@@ -60,15 +60,15 @@ export function StartTimePicker({
     setDate(value);
   }, [value]);
 
-  const invalidDate = !date.isValid();
+  const invalidDate = !date.isValid;
 
   const openDatePickerDialogue = useCallback(
-    (date: Moment | null) => {
+    (date: DateTime | null) => {
       return t(
         'dateTimePickers.openStartTimePicker',
         'Choose start time, selected time is  {{date, datetime}}',
         {
-          date: date?.toDate(),
+          date: date?.toJSDate(),
           formatParams: {
             date: timeOnlyDateFormat,
           },
@@ -79,14 +79,15 @@ export function StartTimePicker({
   );
 
   const handleOnChange = useCallback(
-    (date: Moment | null) => {
-      // It is necessary to clone the moment object
-      // (https://github.com/mui/material-ui-pickers/issues/359#issuecomment-381566442)
-      const newValue = moment(date?.toDate()).seconds(0).milliseconds(0);
+    (date: DateTime | null) => {
+      const newValue = (date ?? DateTime.now()).set({
+        second: 0,
+        millisecond: 0,
+      });
 
       setDate(newValue);
 
-      if (date?.isValid()) {
+      if (date?.isValid) {
         onChange(newValue);
       }
     },

--- a/matrix-meetings-widget/src/components/common/DateTimePickers/StartTimePicker.tsx
+++ b/matrix-meetings-widget/src/components/common/DateTimePickers/StartTimePicker.tsx
@@ -80,10 +80,7 @@ export function StartTimePicker({
 
   const handleOnChange = useCallback(
     (date: DateTime | null) => {
-      const newValue = (date ?? DateTime.now()).set({
-        second: 0,
-        millisecond: 0,
-      });
+      const newValue = (date ?? DateTime.now()).startOf('minute');
 
       setDate(newValue);
 

--- a/matrix-meetings-widget/src/components/common/DateTimePickers/useDatePickersState.test.tsx
+++ b/matrix-meetings-widget/src/components/common/DateTimePickers/useDatePickersState.test.tsx
@@ -16,7 +16,6 @@
 
 import { renderHook } from '@testing-library/react-hooks';
 import { DateTime } from 'luxon';
-import moment from 'moment';
 import { mockMeeting } from '../../../lib/testUtils';
 import { useDatePickersState } from './useDatePickersState';
 
@@ -31,8 +30,8 @@ describe('useDatePickersState', () => {
     it('should return no error if values are correct', () => {
       const { result } = renderHook(() =>
         useDatePickersState({
-          startTime: moment('2022-01-02T13:10:00Z'),
-          endTime: moment('2022-01-02T15:30:00Z'),
+          startTime: DateTime.fromISO('2022-01-02T13:10:00Z'),
+          endTime: DateTime.fromISO('2022-01-02T15:30:00Z'),
         })
       );
 
@@ -40,15 +39,15 @@ describe('useDatePickersState', () => {
         showDatePickers: true,
         startDateError: false,
         endDateError: false,
-        minStartDate: expect.moment('2022-01-02T13:10:00.000Z'),
+        minStartDate: DateTime.fromISO('2022-01-02T13:10:00.000Z'),
       });
     });
 
     it('should return error if start date is in the past', () => {
       const { result } = renderHook(() =>
         useDatePickersState({
-          startTime: moment('2022-01-02T12:15:00Z'),
-          endTime: moment('2022-01-02T13:30:00Z'),
+          startTime: DateTime.fromISO('2022-01-02T12:15:00Z'),
+          endTime: DateTime.fromISO('2022-01-02T13:30:00Z'),
         })
       );
 
@@ -56,15 +55,15 @@ describe('useDatePickersState', () => {
         showDatePickers: true,
         startDateError: 'Meeting cannot start in the past.',
         endDateError: false,
-        minStartDate: expect.moment('2022-01-02T13:10:00.000Z'),
+        minStartDate: DateTime.fromISO('2022-01-02T13:10:00.000Z'),
       });
     });
 
     it('should return error if start date is before the start of the meeting series', () => {
       const { result } = renderHook(() =>
         useDatePickersState({
-          startTime: moment('2022-01-01T12:10:00Z'),
-          endTime: moment('2022-01-02T13:30:00Z'),
+          startTime: DateTime.fromISO('2022-01-01T12:10:00Z'),
+          endTime: DateTime.fromISO('2022-01-02T13:30:00Z'),
           minStartTimeOverride: DateTime.fromISO('2022-01-01T12:15:00Z'),
         })
       );
@@ -73,15 +72,15 @@ describe('useDatePickersState', () => {
         showDatePickers: true,
         startDateError: 'Meeting cannot start in the past.',
         endDateError: false,
-        minStartDate: expect.moment('2022-01-01T12:15:00.000Z'),
+        minStartDate: DateTime.fromISO('2022-01-01T12:15:00.000Z'),
       });
     });
 
     it('should return error if end date is before start date', () => {
       const { result } = renderHook(() =>
         useDatePickersState({
-          startTime: moment('2022-01-02T14:15:00Z'),
-          endTime: moment('2022-01-02T14:00:00Z'),
+          startTime: DateTime.fromISO('2022-01-02T14:15:00Z'),
+          endTime: DateTime.fromISO('2022-01-02T14:00:00Z'),
         })
       );
 
@@ -89,7 +88,7 @@ describe('useDatePickersState', () => {
         showDatePickers: true,
         startDateError: false,
         endDateError: 'Meeting should start before it ends.',
-        minStartDate: expect.moment('2022-01-02T13:10:00.000Z'),
+        minStartDate: DateTime.fromISO('2022-01-02T13:10:00.000Z'),
       });
     });
   });
@@ -98,8 +97,8 @@ describe('useDatePickersState', () => {
     it('should hide date pickers if parent is a single day meeting', () => {
       const { result } = renderHook(() =>
         useDatePickersState({
-          startTime: moment('2022-01-02T14:15:00Z'),
-          endTime: moment('2022-01-02T14:30:00Z'),
+          startTime: DateTime.fromISO('2022-01-02T14:15:00Z'),
+          endTime: DateTime.fromISO('2022-01-02T14:30:00Z'),
           parentMeeting: mockMeeting({
             content: {
               startTime: '2022-01-02T14:00:00Z',
@@ -113,15 +112,15 @@ describe('useDatePickersState', () => {
         showDatePickers: false,
         startDateError: false,
         endDateError: false,
-        minStartDate: expect.moment('2022-01-02T14:00:00Z'),
+        minStartDate: DateTime.fromISO('2022-01-02T14:00:00Z'),
       });
     });
 
     it('should show date pickers if parent is a multi day meeting', () => {
       const { result } = renderHook(() =>
         useDatePickersState({
-          startTime: moment('2022-01-02T14:15:00Z'),
-          endTime: moment('2022-01-02T14:30:00Z'),
+          startTime: DateTime.fromISO('2022-01-02T14:15:00Z'),
+          endTime: DateTime.fromISO('2022-01-02T14:30:00Z'),
           parentMeeting: mockMeeting({
             content: {
               startTime: '2022-01-02T14:00:00Z',
@@ -135,15 +134,15 @@ describe('useDatePickersState', () => {
         showDatePickers: true,
         startDateError: false,
         endDateError: false,
-        minStartDate: expect.moment('2022-01-02T14:00:00Z'),
+        minStartDate: DateTime.fromISO('2022-01-02T14:00:00Z'),
       });
     });
 
     it('should return error if start time is too early on single day meeting', () => {
       const { result } = renderHook(() =>
         useDatePickersState({
-          startTime: moment('2022-01-02T13:55:00Z'),
-          endTime: moment('2022-01-02T14:10:00Z'),
+          startTime: DateTime.fromISO('2022-01-02T13:55:00Z'),
+          endTime: DateTime.fromISO('2022-01-02T14:10:00Z'),
           parentMeeting: mockMeeting({
             content: {
               startTime: '2022-01-02T14:00:00Z',
@@ -158,15 +157,15 @@ describe('useDatePickersState', () => {
         startDateError:
           'Breakout session should start between 2:00 PM and 3:00 PM.',
         endDateError: false,
-        minStartDate: expect.moment('2022-01-02T14:00:00Z'),
+        minStartDate: DateTime.fromISO('2022-01-02T14:00:00Z'),
       });
     });
 
     it('should return error if start time is too early on multi day meeting', () => {
       const { result } = renderHook(() =>
         useDatePickersState({
-          startTime: moment('2022-01-02T13:55:00Z'),
-          endTime: moment('2022-01-02T14:10:00Z'),
+          startTime: DateTime.fromISO('2022-01-02T13:55:00Z'),
+          endTime: DateTime.fromISO('2022-01-02T14:10:00Z'),
           parentMeeting: mockMeeting({
             content: {
               startTime: '2022-01-02T14:00:00Z',
@@ -182,15 +181,15 @@ describe('useDatePickersState', () => {
           /Breakout session should start between January 2, 2022(,| at) 2:00 PM and January 3, 2022(,| at) 3:00 PM/
         ),
         endDateError: false,
-        minStartDate: expect.moment('2022-01-02T14:00:00Z'),
+        minStartDate: DateTime.fromISO('2022-01-02T14:00:00Z'),
       });
     });
 
     it('should return error if end time is too early on single day meeting', () => {
       const { result } = renderHook(() =>
         useDatePickersState({
-          startTime: moment('2022-01-02T13:40:00Z'),
-          endTime: moment('2022-01-02T13:55:00Z'),
+          startTime: DateTime.fromISO('2022-01-02T13:40:00Z'),
+          endTime: DateTime.fromISO('2022-01-02T13:55:00Z'),
           parentMeeting: mockMeeting({
             content: {
               startTime: '2022-01-02T14:00:00Z',
@@ -206,15 +205,15 @@ describe('useDatePickersState', () => {
           'Breakout session should start between 2:00 PM and 3:00 PM.',
         endDateError:
           'Breakout session should end between 2:00 PM and 3:00 PM.',
-        minStartDate: expect.moment('2022-01-02T14:00:00Z'),
+        minStartDate: DateTime.fromISO('2022-01-02T14:00:00Z'),
       });
     });
 
     it('should return error if end time is too early on multi day meeting', () => {
       const { result } = renderHook(() =>
         useDatePickersState({
-          startTime: moment('2022-01-02T13:40:00Z'),
-          endTime: moment('2022-01-02T13:55:00Z'),
+          startTime: DateTime.fromISO('2022-01-02T13:40:00Z'),
+          endTime: DateTime.fromISO('2022-01-02T13:55:00Z'),
           parentMeeting: mockMeeting({
             content: {
               startTime: '2022-01-02T14:00:00Z',
@@ -232,15 +231,15 @@ describe('useDatePickersState', () => {
         endDateError: expect.stringMatching(
           /Breakout session should end between January 2, 2022(,| at) 2:00 PM and January 3, 2022(,| at) 3:00 PM/
         ),
-        minStartDate: expect.moment('2022-01-02T14:00:00Z'),
+        minStartDate: DateTime.fromISO('2022-01-02T14:00:00Z'),
       });
     });
 
     it('should return error if end time is too late on single day meeting', () => {
       const { result } = renderHook(() =>
         useDatePickersState({
-          startTime: moment('2022-01-02T14:15:00Z'),
-          endTime: moment('2022-01-02T15:30:00Z'),
+          startTime: DateTime.fromISO('2022-01-02T14:15:00Z'),
+          endTime: DateTime.fromISO('2022-01-02T15:30:00Z'),
           parentMeeting: mockMeeting({
             content: {
               startTime: '2022-01-02T14:00:00Z',
@@ -255,15 +254,15 @@ describe('useDatePickersState', () => {
         startDateError: false,
         endDateError:
           'Breakout session should end between 2:00 PM and 3:00 PM.',
-        minStartDate: expect.moment('2022-01-02T14:00:00Z'),
+        minStartDate: DateTime.fromISO('2022-01-02T14:00:00Z'),
       });
     });
 
     it('should return error if end time is too late on multi day meeting', () => {
       const { result } = renderHook(() =>
         useDatePickersState({
-          startTime: moment('2022-01-02T14:15:00Z'),
-          endTime: moment('2022-01-03T15:30:00Z'),
+          startTime: DateTime.fromISO('2022-01-02T14:15:00Z'),
+          endTime: DateTime.fromISO('2022-01-03T15:30:00Z'),
           parentMeeting: mockMeeting({
             content: {
               startTime: '2022-01-02T14:00:00Z',
@@ -279,15 +278,15 @@ describe('useDatePickersState', () => {
         endDateError: expect.stringMatching(
           /Breakout session should end between January 2, 2022(,| at) 2:00 PM and January 3, 2022(,| at) 3:00 PM./
         ),
-        minStartDate: expect.moment('2022-01-02T14:00:00Z'),
+        minStartDate: DateTime.fromISO('2022-01-02T14:00:00Z'),
       });
     });
 
     it('should return error if end time is before start date on single day meeting', () => {
       const { result } = renderHook(() =>
         useDatePickersState({
-          startTime: moment('2022-01-02T14:15:00Z'),
-          endTime: moment('2022-01-02T14:10:00Z'),
+          startTime: DateTime.fromISO('2022-01-02T14:15:00Z'),
+          endTime: DateTime.fromISO('2022-01-02T14:10:00Z'),
           parentMeeting: mockMeeting({
             content: {
               startTime: '2022-01-02T14:00:00Z',
@@ -301,15 +300,15 @@ describe('useDatePickersState', () => {
         showDatePickers: false,
         startDateError: false,
         endDateError: 'Breakout session should start before it ends.',
-        minStartDate: expect.moment('2022-01-02T14:00:00Z'),
+        minStartDate: DateTime.fromISO('2022-01-02T14:00:00Z'),
       });
     });
 
     it('should return error if end time is before start date on multi day meeting', () => {
       const { result } = renderHook(() =>
         useDatePickersState({
-          startTime: moment('2022-01-02T14:15:00Z'),
-          endTime: moment('2022-01-02T14:10:00Z'),
+          startTime: DateTime.fromISO('2022-01-02T14:15:00Z'),
+          endTime: DateTime.fromISO('2022-01-02T14:10:00Z'),
           parentMeeting: mockMeeting({
             content: {
               startTime: '2022-01-02T14:00:00Z',
@@ -323,7 +322,7 @@ describe('useDatePickersState', () => {
         showDatePickers: true,
         startDateError: false,
         endDateError: 'Breakout session should start before it ends.',
-        minStartDate: expect.moment('2022-01-02T14:00:00Z'),
+        minStartDate: DateTime.fromISO('2022-01-02T14:00:00Z'),
       });
     });
   });

--- a/matrix-meetings-widget/src/components/common/DateTimePickers/useDatePickersState.ts
+++ b/matrix-meetings-widget/src/components/common/DateTimePickers/useDatePickersState.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { DateTime } from 'luxon';
-import moment, { Moment } from 'moment';
+import { DateTime, Interval } from 'luxon';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getInitialMeetingTimes } from '../../../lib/utils';
@@ -24,15 +23,15 @@ import { fullLongDateFormat, timeOnlyDateFormat } from './dateFormat';
 
 type DatePickersState = {
   showDatePickers: boolean;
-  minStartDate: Moment;
+  minStartDate: DateTime;
   startDateError: false | string;
   endDateError: false | string;
 };
 
 type UseDatePickersStateProps = {
   parentMeeting?: Meeting;
-  startTime: Moment;
-  endTime: Moment;
+  startTime: DateTime;
+  endTime: DateTime;
   minStartTimeOverride?: DateTime;
 };
 
@@ -57,13 +56,13 @@ export function useDatePickersState({
     if (!parentMeeting) {
       // Meeting mode
       const startDateError =
-        startTime.isBefore(moment(getMinStartDate().toISO())) &&
+        startTime < getMinStartDate() &&
         t(
           'dateTimePickers.error.meetingStartTooEarly',
           'Meeting cannot start in the past.'
         );
       const endDateError =
-        endTime.isSameOrBefore(startTime) &&
+        endTime <= startTime &&
         t(
           'dateTimePickers.error.meetingStartBeforeEnd',
           'Meeting should start before it ends.'
@@ -73,27 +72,24 @@ export function useDatePickersState({
         showDatePickers: true,
         startDateError,
         endDateError,
-        minStartDate: moment(getMinStartDate().toISO()),
+        minStartDate: getMinStartDate(),
       };
     } else {
       // Breakout session mode
-      const isMeetingSpanningSingleDay = moment(
-        getMinStartDate().toISO()
-      ).isSame(moment(maxEndDate.toISO()), 'day');
+      const isMeetingSpanningSingleDay = getMinStartDate().hasSame(
+        maxEndDate,
+        'day'
+      );
 
-      const isInvalidStartTime = !startTime.isBetween(
-        moment(getMinStartDate().toISO()),
-        moment(maxEndDate.toISO()),
-        null,
-        '[]'
-      );
-      const isInvalidEndTime = !endTime.isBetween(
-        moment(getMinStartDate().toISO()),
-        moment(maxEndDate.toISO()),
-        null,
-        '[]'
-      );
-      const endTimeBeforeStart = endTime.isBefore(startTime);
+      const isInvalidStartTime =
+        !Interval.fromDateTimes(getMinStartDate(), maxEndDate).contains(
+          startTime
+        ) || startTime.hasSame(maxEndDate, 'millisecond');
+      const isInvalidEndTime =
+        !Interval.fromDateTimes(getMinStartDate(), maxEndDate).contains(
+          endTime
+        ) || endTime.hasSame(maxEndDate, 'millisecond');
+      const endTimeBeforeStart = endTime < startTime;
 
       const formatParams = isMeetingSpanningSingleDay
         ? timeOnlyDateFormat
@@ -105,8 +101,8 @@ export function useDatePickersState({
           'dateTimePickers.error.breakoutSessionInvalidStartTime',
           'Breakout session should start between {{minDate, datetime}} and {{maxDate, datetime}}.',
           {
-            minDate: moment(getMinStartDate().toISO()),
-            maxDate: moment(maxEndDate.toISO()),
+            minDate: getMinStartDate(),
+            maxDate: maxEndDate,
             formatParams: {
               minDate: formatParams,
               maxDate: formatParams,
@@ -125,8 +121,8 @@ export function useDatePickersState({
             'dateTimePickers.error.breakoutSessionInvalidEndTime',
             'Breakout session should end between {{minDate, datetime}} and {{maxDate, datetime}}.',
             {
-              minDate: moment(getMinStartDate().toISO()),
-              maxDate: moment(maxEndDate.toISO()),
+              minDate: getMinStartDate(),
+              maxDate: maxEndDate,
               formatParams: {
                 minDate: formatParams,
                 maxDate: formatParams,
@@ -138,7 +134,7 @@ export function useDatePickersState({
         showDatePickers: !isMeetingSpanningSingleDay,
         startDateError,
         endDateError,
-        minStartDate: moment(getMinStartDate().toISO()),
+        minStartDate: getMinStartDate(),
       };
     }
   }, [endTime, getMinStartDate, maxEndDate, parentMeeting, startTime, t]);

--- a/matrix-meetings-widget/src/components/common/DateTimePickers/useDatePickersState.ts
+++ b/matrix-meetings-widget/src/components/common/DateTimePickers/useDatePickersState.ts
@@ -81,14 +81,14 @@ export function useDatePickersState({
         'day'
       );
 
-      const isInvalidStartTime =
-        !Interval.fromDateTimes(getMinStartDate(), maxEndDate).contains(
-          startTime
-        ) || startTime.hasSame(maxEndDate, 'millisecond');
-      const isInvalidEndTime =
-        !Interval.fromDateTimes(getMinStartDate(), maxEndDate).contains(
-          endTime
-        ) || endTime.hasSame(maxEndDate, 'millisecond');
+      const isInvalidStartTime = !Interval.fromDateTimes(
+        getMinStartDate(),
+        maxEndDate.plus(1)
+      ).contains(startTime);
+      const isInvalidEndTime = !Interval.fromDateTimes(
+        getMinStartDate(),
+        maxEndDate.plus(1)
+      ).contains(endTime);
       const endTimeBeforeStart = endTime < startTime;
 
       const formatParams = isMeetingSpanningSingleDay

--- a/matrix-meetings-widget/src/components/common/LocalizationProvider.tsx
+++ b/matrix-meetings-widget/src/components/common/LocalizationProvider.tsx
@@ -26,10 +26,8 @@ import { AdapterLuxonWeekday } from './AdapterLuxonWeekday';
 export function LocalizationProvider({ children }: PropsWithChildren<{}>) {
   const { i18n } = useTranslation();
   const language: string | undefined = i18n.languages?.[0];
-  const { adapterLocale, locale } =
-    language && new Intl.Locale(language).language === 'de'
-      ? { adapterLocale: 'de-DE', locale: deDE }
-      : { adapterLocale: 'en-US', locale: enUS };
+  const locale =
+    language && new Intl.Locale(language).language === 'de' ? deDE : enUS;
 
   return (
     <MuiLocalizationProvider
@@ -37,7 +35,7 @@ export function LocalizationProvider({ children }: PropsWithChildren<{}>) {
       localeText={
         locale.components.MuiLocalizationProvider.defaultProps.localeText
       }
-      adapterLocale={adapterLocale}
+      adapterLocale={language}
     >
       {children}
     </MuiLocalizationProvider>

--- a/matrix-meetings-widget/src/components/common/LocalizationProvider.tsx
+++ b/matrix-meetings-widget/src/components/common/LocalizationProvider.tsx
@@ -19,9 +19,9 @@ import {
   enUS,
   LocalizationProvider as MuiLocalizationProvider,
 } from '@mui/x-date-pickers';
-import { AdapterMoment } from '@mui/x-date-pickers/AdapterMoment';
 import { PropsWithChildren } from 'react';
 import { useTranslation } from 'react-i18next';
+import { AdapterLuxonWeekday } from './AdapterLuxonWeekday';
 
 export function LocalizationProvider({ children }: PropsWithChildren<{}>) {
   const { i18n } = useTranslation();
@@ -31,7 +31,7 @@ export function LocalizationProvider({ children }: PropsWithChildren<{}>) {
 
   return (
     <MuiLocalizationProvider
-      dateAdapter={AdapterMoment}
+      dateAdapter={AdapterLuxonWeekday}
       localeText={
         locale.components.MuiLocalizationProvider.defaultProps.localeText
       }

--- a/matrix-meetings-widget/src/components/common/LocalizationProvider.tsx
+++ b/matrix-meetings-widget/src/components/common/LocalizationProvider.tsx
@@ -26,8 +26,10 @@ import { AdapterLuxonWeekday } from './AdapterLuxonWeekday';
 export function LocalizationProvider({ children }: PropsWithChildren<{}>) {
   const { i18n } = useTranslation();
   const language: string | undefined = i18n.languages?.[0];
-  const locale =
-    language && new Intl.Locale(language).language === 'de' ? deDE : enUS;
+  const { adapterLocale, locale } =
+    language && new Intl.Locale(language).language === 'de'
+      ? { adapterLocale: 'de-DE', locale: deDE }
+      : { adapterLocale: 'en-US', locale: enUS };
 
   return (
     <MuiLocalizationProvider
@@ -35,6 +37,7 @@ export function LocalizationProvider({ children }: PropsWithChildren<{}>) {
       localeText={
         locale.components.MuiLocalizationProvider.defaultProps.localeText
       }
+      adapterLocale={adapterLocale}
     >
       {children}
     </MuiLocalizationProvider>

--- a/matrix-meetings-widget/src/components/meetings/MeetingsFilter/MeetingsFilter.tsx
+++ b/matrix-meetings-widget/src/components/meetings/MeetingsFilter/MeetingsFilter.tsx
@@ -50,7 +50,7 @@ export const MeetingsFilter = ({
   useEffect(() => {
     setFromDate((old) => {
       const newDate = DateTime.fromISO(filters.startDate);
-      if (!newDate.hasSame(old, 'millisecond')) {
+      if (+newDate !== +old) {
         return newDate;
       }
 
@@ -58,7 +58,7 @@ export const MeetingsFilter = ({
     });
     setToDate((old) => {
       const newDate = DateTime.fromISO(filters.endDate);
-      if (!newDate.hasSame(old, 'millisecond')) {
+      if (+newDate !== +old) {
         return newDate;
       }
 

--- a/matrix-meetings-widget/src/components/meetings/MeetingsFilter/MeetingsFilter.tsx
+++ b/matrix-meetings-widget/src/components/meetings/MeetingsFilter/MeetingsFilter.tsx
@@ -17,7 +17,7 @@
 import SearchIcon from '@mui/icons-material/Search';
 import { InputAdornment, Stack, TextField } from '@mui/material';
 import { isEqual } from 'lodash';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import {
   ChangeEvent,
   Dispatch,
@@ -41,22 +41,24 @@ export const MeetingsFilter = ({
 }: MeetingsFilterProps) => {
   const { t } = useTranslation();
 
-  const [fromDate, setFromDate] = useState(() => moment(filters.startDate));
-  const [toDate, setToDate] = useState(() => moment(filters.endDate));
+  const [fromDate, setFromDate] = useState(() =>
+    DateTime.fromISO(filters.startDate)
+  );
+  const [toDate, setToDate] = useState(() => DateTime.fromISO(filters.endDate));
   const [filterText, setFilterText] = useState(filters.filterText);
 
   useEffect(() => {
     setFromDate((old) => {
-      const newDate = moment(filters.startDate);
-      if (!newDate.isSame(old)) {
+      const newDate = DateTime.fromISO(filters.startDate);
+      if (!newDate.hasSame(old, 'millisecond')) {
         return newDate;
       }
 
       return old;
     });
     setToDate((old) => {
-      const newDate = moment(filters.endDate);
-      if (!newDate.isSame(old)) {
+      const newDate = DateTime.fromISO(filters.endDate);
+      if (!newDate.hasSame(old, 'millisecond')) {
         return newDate;
       }
 
@@ -68,8 +70,8 @@ export const MeetingsFilter = ({
   useEffect(() => {
     onFiltersChange((oldFilters) => {
       const newFilters = {
-        startDate: fromDate.toISOString(),
-        endDate: toDate.toISOString(),
+        startDate: fromDate.toISO(),
+        endDate: toDate.toISO(),
         filterText,
       };
 
@@ -90,8 +92,8 @@ export const MeetingsFilter = ({
 
   const handleOnRangeChange = useCallback(
     (startDate: string, endDate: string) => {
-      setFromDate(moment(startDate));
-      setToDate(moment(endDate));
+      setFromDate(DateTime.fromISO(startDate));
+      setToDate(DateTime.fromISO(endDate));
     },
     []
   );
@@ -99,9 +101,9 @@ export const MeetingsFilter = ({
   return (
     <Stack spacing={1}>
       <DateRangePicker
-        endDate={toDate.toISOString()}
+        endDate={toDate.toISO()}
         onRangeChange={handleOnRangeChange}
-        startDate={fromDate.toISOString()}
+        startDate={fromDate.toISO()}
       />
 
       <TextField

--- a/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/CustomRecurringMeeting/CustomMonthlyRecurringMeeting.tsx
+++ b/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/CustomRecurringMeeting/CustomMonthlyRecurringMeeting.tsx
@@ -25,7 +25,7 @@ import {
   TextField,
 } from '@mui/material';
 import { unstable_useId as useId, visuallyHidden } from '@mui/utils';
-import moment from 'moment';
+import { Info } from 'luxon';
 import { ChangeEvent, Dispatch, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CustomRuleMode } from '../state';
@@ -158,7 +158,7 @@ export const CustomMonthlyRecurringMeeting = ({
                     'The meeting is repeated monthly on {{ordinal}} {{weekday}}',
                     {
                       ordinal: getOrdinalLabel(customNth, t),
-                      weekday: moment.weekdays(customWeekday + 1),
+                      weekday: Info.weekdays()[customWeekday],
                     }
                   ),
                 }}

--- a/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/CustomRecurringMeeting/CustomWeeklyRecurringMeeting.tsx
+++ b/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/CustomRecurringMeeting/CustomWeeklyRecurringMeeting.tsx
@@ -24,9 +24,9 @@ import {
 } from '@mui/material';
 import { unstable_useId as useId } from '@mui/utils';
 import { sortBy } from 'lodash';
-import moment from 'moment';
 import React, { Dispatch, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import { localeWeekdays } from '../../../../lib/utils';
 import { convertWeekdayFromLocaleToRRule } from '../utils';
 
 type CustomWeeklyRecurringMeetingProps = {
@@ -70,7 +70,7 @@ export const CustomWeeklyRecurringMeeting = ({
         sx={{ mt: 1 }}
         value={byWeekday}
       >
-        {moment.weekdays(true).map((m, i) => (
+        {localeWeekdays().map((m, i) => (
           <ToggleButton key={i} value={convertWeekdayFromLocaleToRRule(i)}>
             {m}
           </ToggleButton>

--- a/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/CustomRecurringMeeting/CustomYearlyRecurringMeeting.tsx
+++ b/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/CustomRecurringMeeting/CustomYearlyRecurringMeeting.tsx
@@ -25,7 +25,7 @@ import {
   TextField,
 } from '@mui/material';
 import { unstable_useId as useId, visuallyHidden } from '@mui/utils';
-import moment from 'moment';
+import { Info } from 'luxon';
 import { ChangeEvent, Dispatch, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CustomRuleMode } from '../state';
@@ -105,7 +105,7 @@ export const CustomYearlyRecurringMeeting = ({
                     'The meeting is repeated yearly on {{nthMonthday}} {{month}}',
                     {
                       nthMonthday: customNthMonthday,
-                      month: moment.months(customMonth - 1),
+                      month: Info.months()[customMonth - 1],
                     }
                   ),
                 }}
@@ -171,8 +171,8 @@ export const CustomYearlyRecurringMeeting = ({
                     'The meeting is repeated yearly at {{ordinal}} {{weekday}} of {{month}}',
                     {
                       ordinal: getOrdinalLabel(customNth, t),
-                      weekday: moment.weekdays(customWeekday + 1),
-                      month: moment.months(customMonth + 1),
+                      weekday: Info.weekdays()[customWeekday],
+                      month: Info.months()[customMonth + 1],
                     }
                   ),
                 }}

--- a/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/CustomRecurringMeeting/MonthSelect.tsx
+++ b/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/CustomRecurringMeeting/MonthSelect.tsx
@@ -22,7 +22,7 @@ import {
   SelectChangeEvent,
 } from '@mui/material';
 import { unstable_useId as useId, visuallyHidden } from '@mui/utils';
-import moment from 'moment';
+import { Info } from 'luxon';
 import { Dispatch, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -61,7 +61,7 @@ export const MonthSelect = ({
         onChange={handleMonthChange}
         value={month}
       >
-        {moment.months().map((m, i) => (
+        {Info.months().map((m, i) => (
           <MenuItem key={i} value={i + 1}>
             {m}
           </MenuItem>

--- a/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/CustomRecurringMeeting/WeekdaySelect.tsx
+++ b/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/CustomRecurringMeeting/WeekdaySelect.tsx
@@ -22,9 +22,9 @@ import {
   SelectChangeEvent,
 } from '@mui/material';
 import { unstable_useId as useId, visuallyHidden } from '@mui/utils';
-import moment from 'moment';
 import { Dispatch, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import { localeWeekdays } from '../../../../lib/utils';
 import { convertWeekdayFromLocaleToRRule } from '../utils';
 
 export type WeekdaySelectProps = {
@@ -62,7 +62,7 @@ export const WeekdaySelect = ({
         onChange={handleWeekDaysChange}
         value={weekday}
       >
-        {moment.weekdays(true).map((m, i) => (
+        {localeWeekdays().map((m, i) => (
           <MenuItem key={i} value={convertWeekdayFromLocaleToRRule(i)}>
             {m}
           </MenuItem>

--- a/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/RecurrenceEditor.tsx
+++ b/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/RecurrenceEditor.tsx
@@ -26,7 +26,7 @@ import {
 } from '@mui/material';
 import { unstable_useId as useId } from '@mui/utils';
 import { TFunction } from 'i18next';
-import { Moment } from 'moment';
+import { DateTime } from 'luxon';
 import { useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Frequency } from 'rrule';
@@ -143,7 +143,7 @@ export const RecurrenceEditor = ({
   );
 
   const handleUntilDateChange = useCallback(
-    (untilDate: Moment) => {
+    (untilDate: DateTime) => {
       dispatch({ type: 'updateUntilDate', untilDate });
     },
     [dispatch]

--- a/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/RecurringMeetingEnd/RecurringMeetingEnd.test.tsx
+++ b/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/RecurringMeetingEnd/RecurringMeetingEnd.test.tsx
@@ -17,7 +17,7 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import { ComponentType, PropsWithChildren } from 'react';
 import { RecurringMeetingEnd } from '.';
 import { LocalizationProvider } from '../../../common/LocalizationProvider';
@@ -46,7 +46,7 @@ describe('<RecurringMeetingEnd>', () => {
         onUntilDateChange={onUntilDateChange}
         recurrenceEnd={RecurrenceEnd.Never}
         startDate={startDate}
-        untilDate={moment('2022-01-02T13:10:00.000Z')}
+        untilDate={DateTime.fromISO('2022-01-02T13:10:00.000Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -96,7 +96,7 @@ describe('<RecurringMeetingEnd>', () => {
         onUntilDateChange={onUntilDateChange}
         recurrenceEnd={RecurrenceEnd.UntilDate}
         startDate={startDate}
-        untilDate={moment('2022-01-02T13:10:00.000Z')}
+        untilDate={DateTime.fromISO('2022-01-02T13:10:00.000Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -127,7 +127,7 @@ describe('<RecurringMeetingEnd>', () => {
         onUntilDateChange={onUntilDateChange}
         recurrenceEnd={RecurrenceEnd.AfterMeetingCount}
         startDate={startDate}
-        untilDate={moment('2022-01-02T13:10:00.000Z')}
+        untilDate={DateTime.fromISO('2022-01-02T13:10:00.000Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -151,7 +151,7 @@ describe('<RecurringMeetingEnd>', () => {
         onUntilDateChange={onUntilDateChange}
         recurrenceEnd={RecurrenceEnd.Never}
         startDate={startDate}
-        untilDate={moment('2022-01-02T13:10:00.000Z')}
+        untilDate={DateTime.fromISO('2022-01-02T13:10:00.000Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -168,7 +168,7 @@ describe('<RecurringMeetingEnd>', () => {
         onUntilDateChange={onUntilDateChange}
         recurrenceEnd={RecurrenceEnd.UntilDate}
         startDate={startDate}
-        untilDate={moment('2022-01-02T13:10:00.000Z')}
+        untilDate={DateTime.fromISO('2022-01-02T13:10:00.000Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -189,7 +189,7 @@ describe('<RecurringMeetingEnd>', () => {
         onUntilDateChange={onUntilDateChange}
         recurrenceEnd={RecurrenceEnd.Never}
         startDate={startDate}
-        untilDate={moment('2022-01-02T13:10:00.000Z')}
+        untilDate={DateTime.fromISO('2022-01-02T13:10:00.000Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -214,7 +214,7 @@ describe('<RecurringMeetingEnd>', () => {
         onUntilDateChange={onUntilDateChange}
         recurrenceEnd={RecurrenceEnd.Never}
         startDate={startDate}
-        untilDate={moment('2022-01-02T13:10:00.000Z')}
+        untilDate={DateTime.fromISO('2022-01-02T13:10:00.000Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -237,7 +237,7 @@ describe('<RecurringMeetingEnd>', () => {
         onUntilDateChange={onUntilDateChange}
         recurrenceEnd={RecurrenceEnd.UntilDate}
         startDate={startDate}
-        untilDate={moment('2022-01-02T13:10:00.000Z')}
+        untilDate={DateTime.fromISO('2022-01-02T13:10:00.000Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -250,7 +250,7 @@ describe('<RecurringMeetingEnd>', () => {
       { target: { value: '05/05/2022' } }
     );
 
-    expect(onUntilDateChange.mock.calls.at(-1).at(0).toDate()).toEqual(
+    expect(onUntilDateChange.mock.calls.at(-1).at(0).toJSDate()).toEqual(
       // Explicitly choose the end of the day, as until should be inclusive
       new Date('2022-05-05T23:59:59.999Z')
     );
@@ -265,7 +265,7 @@ describe('<RecurringMeetingEnd>', () => {
         onUntilDateChange={onUntilDateChange}
         recurrenceEnd={RecurrenceEnd.AfterMeetingCount}
         startDate={startDate}
-        untilDate={moment('2022-01-02T13:10:00.000Z')}
+        untilDate={DateTime.fromISO('2022-01-02T13:10:00.000Z')}
       />,
       { wrapper: Wrapper }
     );
@@ -289,7 +289,7 @@ describe('<RecurringMeetingEnd>', () => {
         onUntilDateChange={onUntilDateChange}
         recurrenceEnd={RecurrenceEnd.UntilDate}
         startDate={startDate}
-        untilDate={moment.invalid()}
+        untilDate={DateTime.invalid('Wrong')}
       />,
       { wrapper: Wrapper }
     );
@@ -313,7 +313,7 @@ describe('<RecurringMeetingEnd>', () => {
           onUntilDateChange={onUntilDateChange}
           recurrenceEnd={RecurrenceEnd.AfterMeetingCount}
           startDate={startDate}
-          untilDate={moment('2022-01-02T13:10:00.000Z')}
+          untilDate={DateTime.fromISO('2022-01-02T13:10:00.000Z')}
         />,
         { wrapper: Wrapper }
       );

--- a/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/RecurringMeetingEnd/RecurringMeetingEnd.tsx
+++ b/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/RecurringMeetingEnd/RecurringMeetingEnd.tsx
@@ -28,7 +28,7 @@ import {
 } from '@mui/material';
 import { unstable_useId as useId } from '@mui/utils';
 import { DatePicker } from '@mui/x-date-pickers';
-import moment, { Moment } from 'moment';
+import { DateTime } from 'luxon';
 import { ChangeEvent, Dispatch, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { longDateFormat } from '../../../common/DateTimePickers';
@@ -40,8 +40,8 @@ type RecurringMeetingEndProps = {
   onAfterMeetingCountChange: Dispatch<string>;
   recurrenceEnd: RecurrenceEnd;
   onRecurrenceEndChange: Dispatch<RecurrenceEnd>;
-  untilDate: Moment;
-  onUntilDateChange: Dispatch<Moment>;
+  untilDate: DateTime;
+  onUntilDateChange: Dispatch<DateTime>;
 };
 
 export const RecurringMeetingEnd = ({
@@ -73,21 +73,19 @@ export const RecurringMeetingEnd = ({
   );
 
   const handleUntilDateChange = useCallback(
-    (value: Moment | null) => {
-      // It is necessary to clone the moment object
-      // (https://github.com/mui/material-ui-pickers/issues/359#issuecomment-381566442)
-      onUntilDateChange(moment(value?.toDate()).endOf('day'));
+    (value: DateTime | null) => {
+      onUntilDateChange((value ?? DateTime.now()).endOf('day'));
     },
     [onUntilDateChange]
   );
 
   const openDatePickerDialogue = useCallback(
-    (date: Moment | null) => {
+    (date: DateTime | null) => {
       return t(
         'recurrenceEditor.recurringMeetingEnd.untilDateInputOpenDatePicker',
         'Choose date at which the recurring meeting ends, selected date is {{date, datetime}}',
         {
-          date: date?.toDate(),
+          date: date?.toJSDate(),
           formatParams: {
             date: longDateFormat,
           },
@@ -150,7 +148,7 @@ export const RecurringMeetingEnd = ({
                     'recurrenceEditor.recurringMeetingEnd.untilDateLong',
                     'The meeting is repeated till {{date,datetime}}',
                     {
-                      date: untilDate.toDate(),
+                      date: untilDate.toJSDate(),
                       formatParams: {
                         date: longDateFormat,
                       },
@@ -177,7 +175,7 @@ export const RecurringMeetingEnd = ({
           >
             <DatePicker
               disabled={recurrenceEnd !== RecurrenceEnd.UntilDate}
-              minDate={moment(startDate)}
+              minDate={DateTime.fromJSDate(startDate)}
               onChange={handleUntilDateChange}
               value={untilDate}
               slotProps={{
@@ -186,7 +184,7 @@ export const RecurringMeetingEnd = ({
                 },
                 textField: {
                   fullWidth: true,
-                  helperText: !untilDate.isValid()
+                  helperText: !untilDate.isValid
                     ? t(
                         'recurrenceEditor.recurringMeetingEnd.untilDateInputInvalid',
                         'Invalid date'

--- a/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/state.test.ts
+++ b/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/state.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import { Frequency } from 'rrule';
 import {
   CustomRuleMode,
@@ -47,7 +47,7 @@ describe('storeInitializer', () => {
       customNthMonthday: '7',
       customWeekday: 4,
       recurrenceEnd: RecurrenceEnd.Never,
-      untilDate: expect.moment('2027-10-07T23:59:59.999Z'),
+      untilDate: DateTime.fromISO('2027-10-07T23:59:59.999Z'),
       afterMeetingCount: '5',
     });
   });
@@ -71,7 +71,7 @@ describe('storeInitializer', () => {
       customNthMonthday: '7',
       customWeekday: 4,
       recurrenceEnd: RecurrenceEnd.Never,
-      untilDate: expect.moment('2022-11-06T23:59:59.999Z'),
+      untilDate: DateTime.fromISO('2022-11-06T23:59:59.999Z'),
       afterMeetingCount: '30',
     });
   });
@@ -95,7 +95,7 @@ describe('storeInitializer', () => {
       customNthMonthday: '7',
       customWeekday: 4,
       recurrenceEnd: RecurrenceEnd.Never,
-      untilDate: expect.moment('2023-01-06T23:59:59.999Z'),
+      untilDate: DateTime.fromISO('2023-01-06T23:59:59.999Z'),
       afterMeetingCount: '13',
     });
   });
@@ -119,7 +119,7 @@ describe('storeInitializer', () => {
       customNthMonthday: '7',
       customWeekday: 0,
       recurrenceEnd: RecurrenceEnd.Never,
-      untilDate: expect.moment('2023-01-06T23:59:59.999Z'),
+      untilDate: DateTime.fromISO('2023-01-06T23:59:59.999Z'),
       afterMeetingCount: '13',
     });
   });
@@ -143,7 +143,7 @@ describe('storeInitializer', () => {
       customNthMonthday: '7',
       customWeekday: 4,
       recurrenceEnd: RecurrenceEnd.Never,
-      untilDate: expect.moment('2023-10-07T23:59:59.999Z'),
+      untilDate: DateTime.fromISO('2023-10-07T23:59:59.999Z'),
       afterMeetingCount: '12',
     });
   });
@@ -167,7 +167,7 @@ describe('storeInitializer', () => {
       customNthMonthday: '7',
       customWeekday: 4,
       recurrenceEnd: RecurrenceEnd.Never,
-      untilDate: expect.moment('2027-10-07T23:59:59.999Z'),
+      untilDate: DateTime.fromISO('2027-10-07T23:59:59.999Z'),
       afterMeetingCount: '5',
     });
   });
@@ -191,7 +191,7 @@ describe('storeInitializer', () => {
       customNthMonthday: '7',
       customWeekday: 4,
       recurrenceEnd: RecurrenceEnd.Never,
-      untilDate: expect.moment('2022-11-06T23:59:59.999Z'),
+      untilDate: DateTime.fromISO('2022-11-06T23:59:59.999Z'),
       afterMeetingCount: '30',
     });
   });
@@ -215,7 +215,7 @@ describe('storeInitializer', () => {
       customNthMonthday: '7',
       customWeekday: 0,
       recurrenceEnd: RecurrenceEnd.Never,
-      untilDate: expect.moment('2023-01-06T23:59:59.999Z'),
+      untilDate: DateTime.fromISO('2023-01-06T23:59:59.999Z'),
       afterMeetingCount: '13',
     });
   });
@@ -239,7 +239,7 @@ describe('storeInitializer', () => {
       customNthMonthday: '7',
       customWeekday: 0,
       recurrenceEnd: RecurrenceEnd.Never,
-      untilDate: expect.moment('2022-11-06T23:59:59.999Z'),
+      untilDate: DateTime.fromISO('2022-11-06T23:59:59.999Z'),
       afterMeetingCount: '30',
     });
   });
@@ -263,7 +263,7 @@ describe('storeInitializer', () => {
       customNthMonthday: '7',
       customWeekday: 4,
       recurrenceEnd: RecurrenceEnd.Never,
-      untilDate: expect.moment('2023-10-07T23:59:59.999Z'),
+      untilDate: DateTime.fromISO('2023-10-07T23:59:59.999Z'),
       afterMeetingCount: '12',
     });
   });
@@ -287,7 +287,7 @@ describe('storeInitializer', () => {
       customNthMonthday: '7',
       customWeekday: 0,
       recurrenceEnd: RecurrenceEnd.Never,
-      untilDate: expect.moment('2027-10-07T23:59:59.999Z'),
+      untilDate: DateTime.fromISO('2027-10-07T23:59:59.999Z'),
       afterMeetingCount: '5',
     });
   });
@@ -311,7 +311,7 @@ describe('storeInitializer', () => {
       customNthMonthday: '24',
       customWeekday: 5,
       recurrenceEnd: RecurrenceEnd.Never,
-      untilDate: expect.moment('2027-12-24T23:59:59.999Z'),
+      untilDate: DateTime.fromISO('2027-12-24T23:59:59.999Z'),
       afterMeetingCount: '5',
     });
   });
@@ -336,7 +336,7 @@ describe('storeInitializer', () => {
       customNthMonthday: '7',
       customWeekday: 1,
       recurrenceEnd: RecurrenceEnd.Never,
-      untilDate: expect.moment('2023-10-07T23:59:59.999Z'),
+      untilDate: DateTime.fromISO('2023-10-07T23:59:59.999Z'),
       afterMeetingCount: '12',
     });
   });
@@ -360,7 +360,7 @@ describe('storeInitializer', () => {
       customNthMonthday: '7',
       customWeekday: 4,
       recurrenceEnd: RecurrenceEnd.UntilDate,
-      untilDate: expect.moment('2022-10-30T14:00:00.000Z'),
+      untilDate: DateTime.fromISO('2022-10-30T14:00:00.000Z'),
       afterMeetingCount: '30',
     });
   });
@@ -384,7 +384,7 @@ describe('storeInitializer', () => {
       customNthMonthday: '7',
       customWeekday: 4,
       recurrenceEnd: RecurrenceEnd.AfterMeetingCount,
-      untilDate: expect.moment('2022-11-06T23:59:59.999Z'),
+      untilDate: DateTime.fromISO('2022-11-06T23:59:59.999Z'),
       afterMeetingCount: '14',
     });
   });
@@ -407,7 +407,7 @@ describe('reducer', () => {
           customNthMonthday: '7',
           customWeekday: 4,
           recurrenceEnd: RecurrenceEnd.Never,
-          untilDate: moment('2022-03-02T13:10:00.000Z'),
+          untilDate: DateTime.fromISO('2022-03-02T13:10:00.000Z'),
           afterMeetingCount: '10',
         },
         {
@@ -429,7 +429,7 @@ describe('reducer', () => {
       customNthMonthday: '6',
       customWeekday: 4,
       recurrenceEnd: RecurrenceEnd.Never,
-      untilDate: expect.moment('2022-06-05T23:59:59.999Z'),
+      untilDate: DateTime.fromISO('2022-06-05T23:59:59.999Z'),
       afterMeetingCount: '30',
     });
   });
@@ -450,7 +450,7 @@ describe('reducer', () => {
           customNthMonthday: '7',
           customWeekday: 4,
           recurrenceEnd: RecurrenceEnd.Never,
-          untilDate: moment('2022-03-02T13:10:00.000Z'),
+          untilDate: DateTime.fromISO('2022-03-02T13:10:00.000Z'),
           afterMeetingCount: '10',
         },
         {
@@ -472,7 +472,7 @@ describe('reducer', () => {
       customNthMonthday: '7',
       customWeekday: 4,
       recurrenceEnd: RecurrenceEnd.Never,
-      untilDate: expect.moment('2022-03-02T13:10:00.000Z'),
+      untilDate: DateTime.fromISO('2022-03-02T13:10:00.000Z'),
       afterMeetingCount: '10',
     });
   });
@@ -493,7 +493,7 @@ describe('reducer', () => {
           customNthMonthday: '7',
           customWeekday: 4,
           recurrenceEnd: RecurrenceEnd.Never,
-          untilDate: moment('2022-03-02T13:10:00.000Z'),
+          untilDate: DateTime.fromISO('2022-03-02T13:10:00.000Z'),
           afterMeetingCount: '10',
         },
         {
@@ -515,7 +515,7 @@ describe('reducer', () => {
       customNthMonthday: '7',
       customWeekday: 4,
       recurrenceEnd: RecurrenceEnd.Never,
-      untilDate: expect.moment('2022-03-02T13:10:00.000Z'),
+      untilDate: DateTime.fromISO('2022-03-02T13:10:00.000Z'),
       afterMeetingCount: '10',
     });
   });
@@ -536,7 +536,7 @@ describe('reducer', () => {
           customNthMonthday: '7',
           customWeekday: 4,
           recurrenceEnd: RecurrenceEnd.Never,
-          untilDate: moment('2022-03-02T13:10:00.000Z'),
+          untilDate: DateTime.fromISO('2022-03-02T13:10:00.000Z'),
           afterMeetingCount: '10',
         },
         {
@@ -557,7 +557,7 @@ describe('reducer', () => {
       customNthMonthday: '2',
       customWeekday: 6,
       recurrenceEnd: RecurrenceEnd.Never,
-      untilDate: expect.moment('2022-04-03T23:59:59.999Z'),
+      untilDate: DateTime.fromISO('2022-04-03T23:59:59.999Z'),
       afterMeetingCount: '13',
     });
   });
@@ -578,7 +578,7 @@ describe('reducer', () => {
           customNthMonthday: '7',
           customWeekday: 4,
           recurrenceEnd: RecurrenceEnd.Never,
-          untilDate: moment('2022-03-02T13:10:00.000Z'),
+          untilDate: DateTime.fromISO('2022-03-02T13:10:00.000Z'),
           afterMeetingCount: '10',
         },
         {
@@ -599,7 +599,7 @@ describe('reducer', () => {
       customNthMonthday: '2',
       customWeekday: 6,
       recurrenceEnd: RecurrenceEnd.Never,
-      untilDate: expect.moment('2022-03-02T13:10:00.000Z'),
+      untilDate: DateTime.fromISO('2022-03-02T13:10:00.000Z'),
       afterMeetingCount: '10',
     });
   });
@@ -620,7 +620,7 @@ describe('reducer', () => {
           customNthMonthday: '7',
           customWeekday: 4,
           recurrenceEnd: RecurrenceEnd.Never,
-          untilDate: moment('2022-03-02T13:10:00.000Z'),
+          untilDate: DateTime.fromISO('2022-03-02T13:10:00.000Z'),
           afterMeetingCount: '10',
         },
         {
@@ -641,7 +641,7 @@ describe('reducer', () => {
       customNthMonthday: '7',
       customWeekday: 4,
       recurrenceEnd: RecurrenceEnd.Never,
-      untilDate: expect.moment('2022-03-02T13:10:00.000Z'),
+      untilDate: DateTime.fromISO('2022-03-02T13:10:00.000Z'),
       afterMeetingCount: '10',
     });
   });
@@ -662,7 +662,7 @@ describe('reducer', () => {
           customNthMonthday: '7',
           customWeekday: 4,
           recurrenceEnd: RecurrenceEnd.Never,
-          untilDate: moment('2022-03-02T13:10:00.000Z'),
+          untilDate: DateTime.fromISO('2022-03-02T13:10:00.000Z'),
           afterMeetingCount: '10',
         },
         {
@@ -683,7 +683,7 @@ describe('reducer', () => {
       customNthMonthday: '7',
       customWeekday: 4,
       recurrenceEnd: RecurrenceEnd.Never,
-      untilDate: expect.moment('2022-03-02T13:10:00.000Z'),
+      untilDate: DateTime.fromISO('2022-03-02T13:10:00.000Z'),
       afterMeetingCount: '10',
     });
   });
@@ -704,7 +704,7 @@ describe('reducer', () => {
           customNthMonthday: '7',
           customWeekday: 4,
           recurrenceEnd: RecurrenceEnd.Never,
-          untilDate: moment('2022-03-02T13:10:00.000Z'),
+          untilDate: DateTime.fromISO('2022-03-02T13:10:00.000Z'),
           afterMeetingCount: '10',
         },
         {
@@ -725,7 +725,7 @@ describe('reducer', () => {
       customNthMonthday: '7',
       customWeekday: 4,
       recurrenceEnd: RecurrenceEnd.Never,
-      untilDate: expect.moment('2022-03-02T13:10:00.000Z'),
+      untilDate: DateTime.fromISO('2022-03-02T13:10:00.000Z'),
       afterMeetingCount: '10',
     });
   });
@@ -746,7 +746,7 @@ describe('reducer', () => {
           customNthMonthday: '7',
           customWeekday: 4,
           recurrenceEnd: RecurrenceEnd.Never,
-          untilDate: moment('2022-03-02T13:10:00.000Z'),
+          untilDate: DateTime.fromISO('2022-03-02T13:10:00.000Z'),
           afterMeetingCount: '10',
         },
         {
@@ -767,7 +767,7 @@ describe('reducer', () => {
       customNthMonthday: '7',
       customWeekday: 4,
       recurrenceEnd: RecurrenceEnd.Never,
-      untilDate: expect.moment('2022-03-02T13:10:00.000Z'),
+      untilDate: DateTime.fromISO('2022-03-02T13:10:00.000Z'),
       afterMeetingCount: '10',
     });
   });
@@ -788,7 +788,7 @@ describe('reducer', () => {
           customNthMonthday: '7',
           customWeekday: 4,
           recurrenceEnd: RecurrenceEnd.Never,
-          untilDate: moment('2022-03-02T13:10:00.000Z'),
+          untilDate: DateTime.fromISO('2022-03-02T13:10:00.000Z'),
           afterMeetingCount: '10',
         },
         {
@@ -809,7 +809,7 @@ describe('reducer', () => {
       customNthMonthday: '8',
       customWeekday: 4,
       recurrenceEnd: RecurrenceEnd.Never,
-      untilDate: expect.moment('2022-03-02T13:10:00.000Z'),
+      untilDate: DateTime.fromISO('2022-03-02T13:10:00.000Z'),
       afterMeetingCount: '10',
     });
   });
@@ -830,7 +830,7 @@ describe('reducer', () => {
           customNthMonthday: '7',
           customWeekday: 4,
           recurrenceEnd: RecurrenceEnd.Never,
-          untilDate: moment('2022-03-02T13:10:00.000Z'),
+          untilDate: DateTime.fromISO('2022-03-02T13:10:00.000Z'),
           afterMeetingCount: '10',
         },
         {
@@ -851,7 +851,7 @@ describe('reducer', () => {
       customNthMonthday: '7',
       customWeekday: 5,
       recurrenceEnd: RecurrenceEnd.Never,
-      untilDate: expect.moment('2022-03-02T13:10:00.000Z'),
+      untilDate: DateTime.fromISO('2022-03-02T13:10:00.000Z'),
       afterMeetingCount: '10',
     });
   });
@@ -872,7 +872,7 @@ describe('reducer', () => {
           customNthMonthday: '7',
           customWeekday: 4,
           recurrenceEnd: RecurrenceEnd.Never,
-          untilDate: moment('2022-03-02T13:10:00.000Z'),
+          untilDate: DateTime.fromISO('2022-03-02T13:10:00.000Z'),
           afterMeetingCount: '10',
         },
         {
@@ -893,7 +893,7 @@ describe('reducer', () => {
       customNthMonthday: '7',
       customWeekday: 4,
       recurrenceEnd: RecurrenceEnd.Never,
-      untilDate: expect.moment('2022-03-02T13:10:00.000Z'),
+      untilDate: DateTime.fromISO('2022-03-02T13:10:00.000Z'),
       afterMeetingCount: '10',
     });
   });
@@ -914,7 +914,7 @@ describe('reducer', () => {
           customNthMonthday: '7',
           customWeekday: 4,
           recurrenceEnd: RecurrenceEnd.Never,
-          untilDate: moment('2022-03-02T13:10:00.000Z'),
+          untilDate: DateTime.fromISO('2022-03-02T13:10:00.000Z'),
           afterMeetingCount: '10',
         },
         {
@@ -935,7 +935,7 @@ describe('reducer', () => {
       customNthMonthday: '7',
       customWeekday: 4,
       recurrenceEnd: RecurrenceEnd.UntilDate,
-      untilDate: expect.moment('2022-03-02T13:10:00.000Z'),
+      untilDate: DateTime.fromISO('2022-03-02T13:10:00.000Z'),
       afterMeetingCount: '10',
     });
   });
@@ -956,7 +956,7 @@ describe('reducer', () => {
           customNthMonthday: '7',
           customWeekday: 4,
           recurrenceEnd: RecurrenceEnd.AfterMeetingCount,
-          untilDate: moment('2022-03-02T13:10:00.000Z'),
+          untilDate: DateTime.fromISO('2022-03-02T13:10:00.000Z'),
           afterMeetingCount: '10',
         },
         {
@@ -977,7 +977,7 @@ describe('reducer', () => {
       customNthMonthday: '7',
       customWeekday: 4,
       recurrenceEnd: RecurrenceEnd.AfterMeetingCount,
-      untilDate: expect.moment('2022-03-02T13:10:00.000Z'),
+      untilDate: DateTime.fromISO('2022-03-02T13:10:00.000Z'),
       afterMeetingCount: '15',
     });
   });
@@ -998,12 +998,12 @@ describe('reducer', () => {
           customNthMonthday: '7',
           customWeekday: 4,
           recurrenceEnd: RecurrenceEnd.UntilDate,
-          untilDate: moment('2022-03-02T13:10:00.000Z'),
+          untilDate: DateTime.fromISO('2022-03-02T13:10:00.000Z'),
           afterMeetingCount: '10',
         },
         {
           type: 'updateUntilDate',
-          untilDate: moment('2022-04-02T13:10:00.000Z'),
+          untilDate: DateTime.fromISO('2022-04-02T13:10:00.000Z'),
         }
       )
     ).toEqual({
@@ -1019,7 +1019,7 @@ describe('reducer', () => {
       customNthMonthday: '7',
       customWeekday: 4,
       recurrenceEnd: RecurrenceEnd.UntilDate,
-      untilDate: expect.moment('2022-04-02T13:10:00.000Z'),
+      untilDate: DateTime.fromISO('2022-04-02T13:10:00.000Z'),
       afterMeetingCount: '10',
     });
   });
@@ -1044,7 +1044,7 @@ describe('toRule', () => {
         customWeekday: 4,
         recurrenceEnd: RecurrenceEnd.Never,
         afterMeetingCount: '10',
-        untilDate: moment('2023-10-07T14:15:00.000Z'),
+        untilDate: DateTime.fromISO('2023-10-07T14:15:00.000Z'),
       })
     ).toEqual({
       isValid: true,
@@ -1068,7 +1068,7 @@ describe('toRule', () => {
         customWeekday: 4,
         recurrenceEnd: RecurrenceEnd.Never,
         afterMeetingCount: '10',
-        untilDate: moment('2023-10-07T14:15:00.000Z'),
+        untilDate: DateTime.fromISO('2023-10-07T14:15:00.000Z'),
       })
     ).toEqual({
       isValid: true,
@@ -1092,7 +1092,7 @@ describe('toRule', () => {
         customWeekday: 4,
         recurrenceEnd: RecurrenceEnd.Never,
         afterMeetingCount: '10',
-        untilDate: moment('2023-10-07T14:15:00.000Z'),
+        untilDate: DateTime.fromISO('2023-10-07T14:15:00.000Z'),
       })
     ).toEqual({
       isValid: true,
@@ -1116,7 +1116,7 @@ describe('toRule', () => {
         customWeekday: 4,
         recurrenceEnd: RecurrenceEnd.Never,
         afterMeetingCount: '10',
-        untilDate: moment('2023-10-07T14:15:00.000Z'),
+        untilDate: DateTime.fromISO('2023-10-07T14:15:00.000Z'),
       })
     ).toEqual({
       isValid: true,
@@ -1140,7 +1140,7 @@ describe('toRule', () => {
         customWeekday: 4,
         recurrenceEnd: RecurrenceEnd.Never,
         afterMeetingCount: '10',
-        untilDate: moment('2023-10-07T14:15:00.000Z'),
+        untilDate: DateTime.fromISO('2023-10-07T14:15:00.000Z'),
       })
     ).toEqual({
       isValid: true,
@@ -1164,7 +1164,7 @@ describe('toRule', () => {
         customWeekday: 4,
         recurrenceEnd: RecurrenceEnd.Never,
         afterMeetingCount: '10',
-        untilDate: moment('2023-10-07T14:15:00.000Z'),
+        untilDate: DateTime.fromISO('2023-10-07T14:15:00.000Z'),
       })
     ).toEqual({
       isValid: true,
@@ -1188,7 +1188,7 @@ describe('toRule', () => {
         customWeekday: 4,
         recurrenceEnd: RecurrenceEnd.Never,
         afterMeetingCount: '10',
-        untilDate: moment('2023-10-07T14:15:00.000Z'),
+        untilDate: DateTime.fromISO('2023-10-07T14:15:00.000Z'),
       })
     ).toEqual({
       isValid: true,
@@ -1212,7 +1212,7 @@ describe('toRule', () => {
         customWeekday: 4,
         recurrenceEnd: RecurrenceEnd.Never,
         afterMeetingCount: '10',
-        untilDate: moment('2023-10-07T14:15:00.000Z'),
+        untilDate: DateTime.fromISO('2023-10-07T14:15:00.000Z'),
       })
     ).toEqual({
       isValid: true,
@@ -1236,7 +1236,7 @@ describe('toRule', () => {
         customWeekday: 0,
         recurrenceEnd: RecurrenceEnd.Never,
         afterMeetingCount: '10',
-        untilDate: moment('2023-10-07T14:15:00.000Z'),
+        untilDate: DateTime.fromISO('2023-10-07T14:15:00.000Z'),
       })
     ).toEqual({
       isValid: true,
@@ -1260,7 +1260,7 @@ describe('toRule', () => {
         customWeekday: 4,
         recurrenceEnd: RecurrenceEnd.Never,
         afterMeetingCount: '10',
-        untilDate: moment('2023-10-07T14:15:00.000Z'),
+        untilDate: DateTime.fromISO('2023-10-07T14:15:00.000Z'),
       })
     ).toEqual({
       isValid: true,
@@ -1284,7 +1284,7 @@ describe('toRule', () => {
         customWeekday: 0,
         recurrenceEnd: RecurrenceEnd.Never,
         afterMeetingCount: '10',
-        untilDate: moment('2023-10-07T14:15:00.000Z'),
+        untilDate: DateTime.fromISO('2023-10-07T14:15:00.000Z'),
       })
     ).toEqual({
       isValid: true,
@@ -1308,7 +1308,7 @@ describe('toRule', () => {
         customWeekday: 4,
         recurrenceEnd: RecurrenceEnd.Never,
         afterMeetingCount: '10',
-        untilDate: moment('2023-10-07T14:15:00.000Z'),
+        untilDate: DateTime.fromISO('2023-10-07T14:15:00.000Z'),
       })
     ).toEqual({
       isValid: true,
@@ -1332,7 +1332,7 @@ describe('toRule', () => {
         customWeekday: 4,
         recurrenceEnd: RecurrenceEnd.AfterMeetingCount,
         afterMeetingCount: '10',
-        untilDate: moment('2023-10-07T14:15:00.000Z'),
+        untilDate: DateTime.fromISO('2023-10-07T14:15:00.000Z'),
       })
     ).toEqual({
       isValid: true,
@@ -1356,7 +1356,7 @@ describe('toRule', () => {
         customWeekday: 4,
         recurrenceEnd: RecurrenceEnd.UntilDate,
         afterMeetingCount: '10',
-        untilDate: moment('2023-10-07T14:15:00.000Z'),
+        untilDate: DateTime.fromISO('2023-10-07T14:15:00.000Z'),
       })
     ).toEqual({
       isValid: true,
@@ -1382,7 +1382,7 @@ describe('toRule', () => {
           customWeekday: 4,
           recurrenceEnd: RecurrenceEnd.AfterMeetingCount,
           afterMeetingCount,
-          untilDate: moment('2023-10-07T14:15:00.000Z'),
+          untilDate: DateTime.fromISO('2023-10-07T14:15:00.000Z'),
         })
       ).toEqual({
         isValid: false,
@@ -1407,7 +1407,7 @@ describe('toRule', () => {
         customWeekday: 4,
         recurrenceEnd: RecurrenceEnd.UntilDate,
         afterMeetingCount: '10',
-        untilDate: moment(''),
+        untilDate: DateTime.fromISO(''),
       })
     ).toEqual({
       isValid: false,
@@ -1433,7 +1433,7 @@ describe('toRule', () => {
           customWeekday: 4,
           recurrenceEnd: RecurrenceEnd.Never,
           afterMeetingCount: '10',
-          untilDate: moment('2023-10-07T14:15:00.000Z'),
+          untilDate: DateTime.fromISO('2023-10-07T14:15:00.000Z'),
         })
       ).toEqual({
         isValid: false,
@@ -1460,7 +1460,7 @@ describe('toRule', () => {
           customWeekday: 4,
           recurrenceEnd: RecurrenceEnd.Never,
           afterMeetingCount: '10',
-          untilDate: moment('2023-10-07T14:15:00.000Z'),
+          untilDate: DateTime.fromISO('2023-10-07T14:15:00.000Z'),
         })
       ).toEqual({
         isValid: false,

--- a/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/utils/helper.test.ts
+++ b/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/utils/helper.test.ts
@@ -17,7 +17,7 @@
 import { convertWeekdayFromLocaleToRRule, isWeekdays } from './helpers';
 
 describe('convertWeekdayFromLocaleToRRule', () => {
-  it('should convert the moment weekday number to the weekday rrule number', () => {
+  it('should convert the locale weekday number to the weekday rrule number', () => {
     expect(convertWeekdayFromLocaleToRRule(0)).toBe(6);
     expect(convertWeekdayFromLocaleToRRule(1)).toBe(0);
     expect(convertWeekdayFromLocaleToRRule(2)).toBe(1);

--- a/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/utils/helper.test.ts
+++ b/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/utils/helper.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { setLocale } from '../../../../lib/locale';
 import { convertWeekdayFromLocaleToRRule, isWeekdays } from './helpers';
 
 describe('convertWeekdayFromLocaleToRRule', () => {
@@ -26,6 +27,18 @@ describe('convertWeekdayFromLocaleToRRule', () => {
     expect(convertWeekdayFromLocaleToRRule(5)).toBe(4);
     expect(convertWeekdayFromLocaleToRRule(6)).toBe(5);
   });
+});
+
+it('should convert the locale weekday number to the weekday rrule number with german locale', () => {
+  setLocale('de');
+
+  expect(convertWeekdayFromLocaleToRRule(0)).toBe(0);
+  expect(convertWeekdayFromLocaleToRRule(1)).toBe(1);
+  expect(convertWeekdayFromLocaleToRRule(2)).toBe(2);
+  expect(convertWeekdayFromLocaleToRRule(3)).toBe(3);
+  expect(convertWeekdayFromLocaleToRRule(4)).toBe(4);
+  expect(convertWeekdayFromLocaleToRRule(5)).toBe(5);
+  expect(convertWeekdayFromLocaleToRRule(6)).toBe(6);
 });
 
 describe('isWeekdays', () => {

--- a/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/utils/helpers.ts
+++ b/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/utils/helpers.ts
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
+import { Info } from 'luxon';
 import { ByWeekday, RRule, Weekday } from 'rrule';
+import { localeWeekdays } from '../../../../lib/utils';
 
 export function convertWeekdayFromLocaleToRRule(index: number): number {
-  return (index - 1 + 7) % 7;
+  return Info.weekdays().indexOf(localeWeekdays()[index]);
 }
 
 export function normalizeNumeric(

--- a/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/utils/helpers.ts
+++ b/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/utils/helpers.ts
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-import moment from 'moment';
 import { ByWeekday, RRule, Weekday } from 'rrule';
 
 export function convertWeekdayFromLocaleToRRule(index: number): number {
-  return (moment.weekdays().indexOf(moment.weekdays(true, index)) - 1 + 7) % 7;
+  return (index - 1 + 7) % 7;
 }
 
 export function normalizeNumeric(

--- a/matrix-meetings-widget/src/components/meetings/ScheduleMeetingModal/ScheduleMeeting.tsx
+++ b/matrix-meetings-widget/src/components/meetings/ScheduleMeetingModal/ScheduleMeeting.tsx
@@ -29,7 +29,6 @@ import {
 } from '@mui/material';
 import { unstable_useId as useId, visuallyHidden } from '@mui/utils';
 import { DateTime } from 'luxon';
-import moment, { Moment } from 'moment';
 import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -88,17 +87,13 @@ export const ScheduleMeeting = ({
   );
   const [startDate, setStartDate] = useState(
     initialMeeting
-      ? moment(
-          parseICalDate(initialMeeting.calendarEntries[0].dtstart).toJSDate()
-        )
-      : moment(initialStartDate.toISO())
+      ? parseICalDate(initialMeeting.calendarEntries[0].dtstart)
+      : initialStartDate
   );
   const [endDate, setEndDate] = useState(
     initialMeeting
-      ? moment(
-          parseICalDate(initialMeeting.calendarEntries[0].dtend).toJSDate()
-        )
-      : moment(initialEndDate.toISO())
+      ? parseICalDate(initialMeeting.calendarEntries[0].dtend)
+      : initialEndDate
   );
 
   const [participants, setParticipants] = useState<string[]>(() => {
@@ -192,19 +187,19 @@ export const ScheduleMeeting = ({
   );
 
   const handleStartDateChange = useCallback(
-    (value: Moment) => {
+    (value: DateTime) => {
       setStartDate(value);
       setEndDate((currentEndDate) => {
-        const currentDiff = value.diff(startDate);
+        const currentDiff = value.diff(startDate).milliseconds;
 
-        return moment(currentEndDate.toDate()).add(currentDiff);
+        return currentEndDate.plus({ millisecond: currentDiff });
       });
       setIsDirty(true);
     },
     [startDate]
   );
 
-  const handleEndDateChange = useCallback((value: Moment) => {
+  const handleEndDateChange = useCallback((value: DateTime) => {
     setEndDate(value);
     setIsDirty(true);
   }, []);
@@ -346,8 +341,8 @@ export const ScheduleMeeting = ({
       onMeetingChange({
         title: title.trim(),
         description,
-        startTime: startDate.toISOString(),
-        endTime: endDate.toISOString(),
+        startTime: startDate.toISO(),
+        endTime: endDate.toISO(),
         participants,
         powerLevels,
         widgetIds: widgets,
@@ -572,7 +567,7 @@ export const ScheduleMeeting = ({
             isMeetingCreation={isMeetingCreation}
             onChange={handleChangeRecurrence}
             rule={recurrence.rrule}
-            startDate={startDate.toDate()}
+            startDate={startDate.toJSDate()}
           />
         )}
       </Stack>

--- a/matrix-meetings-widget/src/components/meetings/ScheduleMeetingModal/ScheduleMeeting.tsx
+++ b/matrix-meetings-widget/src/components/meetings/ScheduleMeetingModal/ScheduleMeeting.tsx
@@ -190,9 +190,7 @@ export const ScheduleMeeting = ({
     (value: DateTime) => {
       setStartDate(value);
       setEndDate((currentEndDate) => {
-        const currentDiff = value.diff(startDate).milliseconds;
-
-        return currentEndDate.plus({ millisecond: currentDiff });
+        return currentEndDate.plus(value.diff(startDate));
       });
       setIsDirty(true);
     },

--- a/matrix-meetings-widget/src/components/meetings/SetupBreakoutSessionsModal/SetupBreakoutSessions.tsx
+++ b/matrix-meetings-widget/src/components/meetings/SetupBreakoutSessionsModal/SetupBreakoutSessions.tsx
@@ -82,9 +82,7 @@ export const SetupBreakoutSessions = ({
     (value: DateTime) => {
       setStartDate(value);
       setEndDate((currentEndDate) => {
-        const currentDiff = value.diff(startDate).milliseconds;
-
-        return currentEndDate.plus({ millisecond: currentDiff });
+        return currentEndDate.plus(value.diff(startDate));
       });
     },
     [startDate]

--- a/matrix-meetings-widget/src/components/meetings/SetupBreakoutSessionsModal/SetupBreakoutSessions.tsx
+++ b/matrix-meetings-widget/src/components/meetings/SetupBreakoutSessionsModal/SetupBreakoutSessions.tsx
@@ -23,7 +23,7 @@ import {
   TextField,
 } from '@mui/material';
 import { unstable_useId as useId, visuallyHidden } from '@mui/utils';
-import moment, { Moment } from 'moment';
+import { DateTime } from 'luxon';
 import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getInitialMeetingTimes } from '../../../lib/utils';
@@ -57,18 +57,18 @@ export const SetupBreakoutSessions = ({
     () => getInitialMeetingTimes({ parentMeeting }),
     [parentMeeting]
   );
-  const [startDate, setStartDate] = useState(moment(initialStartDate.toISO()));
-  const [endDate, setEndDate] = useState(moment(initialEndDate.toISO()));
+  const [startDate, setStartDate] = useState(initialStartDate);
+  const [endDate, setEndDate] = useState(initialEndDate);
   const [groups, setGroups] = useState<BreakoutSessionGroup[]>([]);
   const [description, setDescription] = useState('');
   const [widgets, setWidgets] = useState<Array<string>>([]);
 
   useEffect(() => {
-    setStartDate(moment(initialStartDate.toISO()));
+    setStartDate(initialStartDate);
   }, [initialStartDate]);
 
   useEffect(() => {
-    moment(initialEndDate.toISO());
+    setEndDate(initialEndDate);
   }, [initialEndDate]);
 
   const handleChangeDescription = useCallback(
@@ -79,18 +79,18 @@ export const SetupBreakoutSessions = ({
   );
 
   const handleStartDateChange = useCallback(
-    (value: Moment) => {
+    (value: DateTime) => {
       setStartDate(value);
       setEndDate((currentEndDate) => {
-        const currentDiff = value.diff(startDate);
+        const currentDiff = value.diff(startDate).milliseconds;
 
-        return moment(currentEndDate.toDate()).add(currentDiff);
+        return currentEndDate.plus({ millisecond: currentDiff });
       });
     },
     [startDate]
   );
 
-  const handleEndDateChange = useCallback((value: Moment) => {
+  const handleEndDateChange = useCallback((value: DateTime) => {
     setEndDate(value);
   }, []);
 
@@ -109,8 +109,8 @@ export const SetupBreakoutSessions = ({
     } else {
       onBreakoutSessionsChange({
         description,
-        startTime: startDate.toISOString(),
-        endTime: endDate.toISOString(),
+        startTime: startDate.toISO(),
+        endTime: endDate.toISO(),
         widgetIds: widgets,
         groups: groups.map((group) => ({
           title: group.title,

--- a/matrix-meetings-widget/src/lib/locale.ts
+++ b/matrix-meetings-widget/src/lib/locale.ts
@@ -15,11 +15,8 @@
  */
 
 import { Settings } from 'luxon';
-import * as moment from 'moment';
-import 'moment/min/locales';
 
 export function setLocale(locale: string): void {
-  moment.locale(locale);
   Settings.defaultLocale = locale;
   document.documentElement.lang = locale;
 }

--- a/matrix-meetings-widget/src/lib/utils/generateFilterRange.ts
+++ b/matrix-meetings-widget/src/lib/utils/generateFilterRange.ts
@@ -15,7 +15,7 @@
  */
 
 import { DateTime, Duration } from 'luxon';
-import moment from 'moment';
+import { getWeekdayShift } from './getWeekdayShift';
 
 export type CalendarViewType = 'day' | 'workWeek' | 'week' | 'month';
 
@@ -27,9 +27,7 @@ export const generateFilterRange = (
   // luxon only supports isoWeekday always returns a day-of-week=1.
   // this duration normalizes it to the configured locale
   const normalizeDuration = Duration.fromObject({
-    day:
-      DateTime.now().startOf('week').weekday -
-      moment.localeData().firstDayOfWeek(),
+    day: getWeekdayShift(),
   });
 
   // Interpret the ISO-date in local time so the startOf and endOf

--- a/matrix-meetings-widget/src/lib/utils/getWeekdayShift.test.ts
+++ b/matrix-meetings-widget/src/lib/utils/getWeekdayShift.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Nordeck IT + Consulting GmbH
+ * Copyright 2023 Nordeck IT + Consulting GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,16 @@
  * limitations under the License.
  */
 
-import { Settings } from 'luxon';
-import { setLocale } from './locale';
+import { setLocale } from '../locale';
+import { getWeekdayShift } from './getWeekdayShift';
 
-describe('setLocale', () => {
-  it('should set luxon locale', () => {
-    setLocale('de');
-
-    expect(Settings.defaultLocale).toEqual('de');
+describe('getWeekdayShift', () => {
+  it('shift 1 day for en locale', () => {
+    expect(getWeekdayShift()).toEqual(1);
   });
 
-  it('should set HTML lang', () => {
+  it('no change for de locale', () => {
     setLocale('de');
-
-    expect(document.documentElement.lang).toEqual('de');
+    expect(getWeekdayShift()).toEqual(0);
   });
 });

--- a/matrix-meetings-widget/src/lib/utils/getWeekdayShift.ts
+++ b/matrix-meetings-widget/src/lib/utils/getWeekdayShift.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Nordeck IT + Consulting GmbH
+ * Copyright 2023 Nordeck IT + Consulting GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,14 @@
  * limitations under the License.
  */
 
-import { Settings } from 'luxon';
-import { setLocale } from './locale';
+import { DateTime, Settings } from 'luxon';
 
-describe('setLocale', () => {
-  it('should set luxon locale', () => {
-    setLocale('de');
-
-    expect(Settings.defaultLocale).toEqual('de');
-  });
-
-  it('should set HTML lang', () => {
-    setLocale('de');
-
-    expect(document.documentElement.lang).toEqual('de');
-  });
-});
+/**
+ * Gets a value that would shift Date Picker week first day in the following order: Monday -> Sunday -> Saturday... .
+ * Negative value would shift in another direction. Zero would keep the default.
+ */
+export function getWeekdayShift(): number {
+  const firstDayOfWeek =
+    new Intl.Locale(Settings.defaultLocale).language === 'de' ? 1 : 0;
+  return DateTime.now().startOf('week').weekday - firstDayOfWeek;
+}

--- a/matrix-meetings-widget/src/lib/utils/index.ts
+++ b/matrix-meetings-widget/src/lib/utils/index.ts
@@ -26,5 +26,7 @@ export { generateFilterRange } from './generateFilterRange';
 export type { CalendarViewType } from './generateFilterRange';
 export { getBotUserId, isBotUser } from './getBotUserId';
 export { getInitialMeetingTimes } from './getInitialMeetingTimes';
+export { getWeekdayShift } from './getWeekdayShift';
 export { isDefined } from './isDefined';
 export { isString } from './isString';
+export { localeWeekdays } from './localeWeekdays';

--- a/matrix-meetings-widget/src/lib/utils/localeWeekdays.test.ts
+++ b/matrix-meetings-widget/src/lib/utils/localeWeekdays.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Nordeck IT + Consulting GmbH
+ * Copyright 2023 Nordeck IT + Consulting GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,32 @@
  * limitations under the License.
  */
 
-import { Settings } from 'luxon';
-import { setLocale } from './locale';
+import { setLocale } from '../locale';
+import { localeWeekdays } from './localeWeekdays';
 
-describe('setLocale', () => {
-  it('should set luxon locale', () => {
-    setLocale('de');
-
-    expect(Settings.defaultLocale).toEqual('de');
+describe('localeWeekdays', () => {
+  it('generate weekdays for en locale', () => {
+    expect(localeWeekdays()).toEqual([
+      'Sunday',
+      'Monday',
+      'Tuesday',
+      'Wednesday',
+      'Thursday',
+      'Friday',
+      'Saturday',
+    ]);
   });
 
-  it('should set HTML lang', () => {
+  it('generate weekdays for de locale', () => {
     setLocale('de');
-
-    expect(document.documentElement.lang).toEqual('de');
+    expect(localeWeekdays()).toEqual([
+      'Montag',
+      'Dienstag',
+      'Mittwoch',
+      'Donnerstag',
+      'Freitag',
+      'Samstag',
+      'Sonntag',
+    ]);
   });
 });

--- a/matrix-meetings-widget/src/lib/utils/localeWeekdays.ts
+++ b/matrix-meetings-widget/src/lib/utils/localeWeekdays.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Info } from 'luxon';
+import { StringUnitLength } from 'luxon/src/misc';
+import { getWeekdayShift } from './getWeekdayShift';
+
+export function localeWeekdays(
+  length?: StringUnitLength,
+  format?: boolean
+): string[] {
+  const day = getWeekdayShift();
+
+  const weekdays = format ? Info.weekdaysFormat(length) : Info.weekdays(length);
+  for (let i = 0; i < Math.abs(day); i++) {
+    if (day > 0) {
+      weekdays.unshift(weekdays.pop()!);
+    } else {
+      weekdays.push(weekdays.shift()!);
+    }
+  }
+
+  return weekdays;
+}

--- a/matrix-meetings-widget/src/setupTests.ts
+++ b/matrix-meetings-widget/src/setupTests.ts
@@ -20,7 +20,6 @@
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
 import { toHaveNoViolations } from 'jest-axe';
-import * as moment from 'moment-timezone';
 import { TextDecoder, TextEncoder } from 'util';
 // Make sure to initialize i18n (see mock below)
 import './i18n';
@@ -78,30 +77,6 @@ beforeEach(() => {
     removeListener: jest.fn(),
   }));
 });
-
-// Custom matcher to compare objects containing moment values
-expect.extend({
-  // ...any other custom matchers.
-  moment(actual, expected) {
-    const pass =
-      moment.default(actual).toISOString() ===
-      moment.default(expected).toISOString();
-    return {
-      pass,
-      message: pass
-        ? () => `expected not to be ${moment.default(expected).toISOString()}`
-        : () => `expected to be ${moment.default(expected).toISOString()}`,
-    };
-  },
-});
-
-declare global {
-  namespace jest {
-    interface Expect {
-      moment(expected: moment.Moment | string | Date): moment.Moment;
-    }
-  }
-}
 
 // Polyfills required for jsdom
 global.TextEncoder = TextEncoder as typeof global.TextEncoder;

--- a/matrix-meetings-widget/src/timezoneMockUtils.ts
+++ b/matrix-meetings-widget/src/timezoneMockUtils.ts
@@ -15,7 +15,6 @@
  */
 
 import { Settings } from 'luxon';
-import moment from 'moment';
 
 // store original instance
 const DateTimeFormat = Intl.DateTimeFormat;
@@ -43,9 +42,6 @@ export function mockDateTimeFormatTimeZone(timeZone: string): void {
       const tzOffset = dateInTargetTZ.getTime() - dateInLocalTZ.getTime();
       return tzOffset / 1000 / 60;
     });
-
-  // Initialize moment.js
-  moment.tz.setDefault(timeZone);
 
   // We want our tests to be in a reproducible time zone, always resulting in
   // the same results, independent from where they are run.

--- a/yarn.lock
+++ b/yarn.lock
@@ -9255,7 +9255,7 @@ moment-timezone@^0.5.43:
   dependencies:
     moment "^2.29.4"
 
-moment@^2.29.3, moment@^2.29.4:
+moment@^2.29.4:
   version "2.29.4"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
   integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==


### PR DESCRIPTION
Changes widget to use `Luxon` instead of `moment`.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [x] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
