### PR TITLE
Fix month value in 'aria-label' of custom yearly recurrence

### DIFF
--- a/.changeset/little-elephants-roll.md
+++ b/.changeset/little-elephants-roll.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-meetings-widget': patch
+---
+
+Fix month value in 'aria-label' of custom yearly recurrence.

--- a/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/CustomRecurringMeeting/CustomRecurringMeeting.test.tsx
+++ b/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/CustomRecurringMeeting/CustomRecurringMeeting.test.tsx
@@ -432,12 +432,12 @@ describe('<CustomRecurringMeeting>', () => {
 
     expect(
       within(group).getByRole('radio', {
-        name: 'The meeting is repeated yearly at third Tuesday of December',
+        name: 'The meeting is repeated yearly at third Tuesday of October',
       })
     ).toBeChecked();
 
     const weekdayGroup = within(group).getByRole('group', {
-      name: 'The meeting is repeated yearly at third Tuesday of December',
+      name: 'The meeting is repeated yearly at third Tuesday of October',
     });
     expect(
       within(weekdayGroup).getByRole('button', { name: 'Ordinal third' })
@@ -802,7 +802,7 @@ describe('<CustomRecurringMeeting>', () => {
 
     await userEvent.click(
       screen.getByRole('radio', {
-        name: 'The meeting is repeated yearly at third Tuesday of December',
+        name: 'The meeting is repeated yearly at third Tuesday of October',
       })
     );
 
@@ -919,7 +919,7 @@ describe('<CustomRecurringMeeting>', () => {
     );
 
     const weekdayGroup = screen.getByRole('group', {
-      name: 'The meeting is repeated yearly at third Tuesday of December',
+      name: 'The meeting is repeated yearly at third Tuesday of October',
     });
 
     await userEvent.click(
@@ -963,7 +963,7 @@ describe('<CustomRecurringMeeting>', () => {
     );
 
     const weekdayGroup = screen.getByRole('group', {
-      name: 'The meeting is repeated yearly at third Tuesday of December',
+      name: 'The meeting is repeated yearly at third Tuesday of October',
     });
 
     await userEvent.click(
@@ -1007,7 +1007,7 @@ describe('<CustomRecurringMeeting>', () => {
     );
 
     const weekdayGroup = screen.getByRole('group', {
-      name: 'The meeting is repeated yearly at third Tuesday of December',
+      name: 'The meeting is repeated yearly at third Tuesday of October',
     });
 
     await userEvent.click(

--- a/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/CustomRecurringMeeting/CustomYearlyRecurringMeeting.tsx
+++ b/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/CustomRecurringMeeting/CustomYearlyRecurringMeeting.tsx
@@ -172,7 +172,7 @@ export const CustomYearlyRecurringMeeting = ({
                     {
                       ordinal: getOrdinalLabel(customNth, t),
                       weekday: moment.weekdays(customWeekday + 1),
-                      month: moment.months(customMonth + 1),
+                      month: moment.months(customMonth - 1),
                     }
                   ),
                 }}

--- a/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/RecurrenceEditor.test.tsx
+++ b/matrix-meetings-widget/src/components/meetings/RecurrenceEditor/RecurrenceEditor.test.tsx
@@ -250,12 +250,12 @@ describe('<RecurrenceEditor>', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole('radio', {
-        name: 'The meeting is repeated yearly at first Sunday of March',
+        name: 'The meeting is repeated yearly at first Sunday of January',
       })
     ).toBeChecked();
 
     const weekdayGroup = screen.getByRole('group', {
-      name: 'The meeting is repeated yearly at first Sunday of March',
+      name: 'The meeting is repeated yearly at first Sunday of January',
     });
     expect(
       within(weekdayGroup).getByRole('button', { name: 'Ordinal first' })


### PR DESCRIPTION
This PR fixes month that is provided into `aria-label` of custom yearly recurrence rule inside of recurrence editor.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [x] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
