### PR TITLE
Include all updates and exclusions of recurring meetings in the ICS file export

### DIFF
--- a/.changeset/breezy-plums-knock.md
+++ b/.changeset/breezy-plums-knock.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-meetings-widget': minor
+---
+
+Include all updates and exclusions of recurring meetings in the ICS file export.

--- a/matrix-meetings-widget/package.json
+++ b/matrix-meetings-widget/package.json
@@ -23,7 +23,6 @@
     "i18next": "^23.4.5",
     "i18next-chained-backend": "^4.4.0",
     "i18next-http-backend": "^2.2.2",
-    "ical-generator": "^5.0.1",
     "joi": "^17.10.2",
     "lodash": "^4.17.20",
     "luxon": "^3.3.0",

--- a/matrix-meetings-widget/src/components/meetings/MeetingCardShareMeetingContent/useDownloadIcsFile.test.tsx
+++ b/matrix-meetings-widget/src/components/meetings/MeetingCardShareMeetingContent/useDownloadIcsFile.test.tsx
@@ -112,8 +112,9 @@ describe('useDownloadIcsFile', () => {
       expect(blobSpy).toHaveBeenLastCalledWith([
         expect.stringContaining(`BEGIN:VEVENT\r
 UID:!meeting-room-id-entry-0\r
-SEQUENCE:0\r
+SEQUENCE:1577872800\r
 DTSTAMP:20200101T100000Z\r
+LAST-MODIFIED:20200101T100000Z\r
 DTSTART:29990101T100000Z\r
 DTEND:29990101T140000Z\r
 SUMMARY:An important meeting\r
@@ -149,8 +150,9 @@ describe('createIcsFile', () => {
       PRODID:-//nordeck.net//matrix-meetings//EN
       BEGIN:VEVENT
       UID:!meeting-room-id-entry-0
-      SEQUENCE:0
+      SEQUENCE:1577872800
       DTSTAMP:20200101T100000Z
+      LAST-MODIFIED:20200101T100000Z
       DTSTART:29990101T100000Z
       DTEND:29990101T140000Z
       SUMMARY:An important meeting
@@ -206,8 +208,9 @@ describe('createIcsFile', () => {
       END:VTIMEZONE
       BEGIN:VEVENT
       UID:!meeting-room-id-entry-0
-      SEQUENCE:0
+      SEQUENCE:1577872800
       DTSTAMP:20200101T100000Z
+      LAST-MODIFIED:20200101T100000Z
       DTSTART;TZID=Europe/Berlin:29990101T100000
       DTEND;TZID=Europe/Berlin:29990101T140000
       SUMMARY:An important meeting
@@ -244,8 +247,9 @@ describe('createIcsFile', () => {
       PRODID:-//nordeck.net//matrix-meetings//EN
       BEGIN:VEVENT
       UID:!meeting-room-id-entry-0
-      SEQUENCE:0
+      SEQUENCE:1577872800
       DTSTAMP:20200101T100000Z
+      LAST-MODIFIED:20200101T100000Z
       DTSTART:29990101T100000Z
       DTEND:29990101T140000Z
       RRULE:FREQ=DAILY
@@ -291,8 +295,9 @@ describe('createIcsFile', () => {
       PRODID:-//nordeck.net//matrix-meetings//EN
       BEGIN:VEVENT
       UID:!meeting-room-id-entry-0
-      SEQUENCE:0
+      SEQUENCE:1577872800
       DTSTAMP:20200101T100000Z
+      LAST-MODIFIED:20200101T100000Z
       DTSTART:29990101T100000Z
       DTEND:29990101T140000Z
       RRULE:FREQ=DAILY
@@ -302,8 +307,9 @@ describe('createIcsFile', () => {
       END:VEVENT
       BEGIN:VEVENT
       UID:!meeting-room-id-entry-0
-      SEQUENCE:0
+      SEQUENCE:1577872800
       DTSTAMP:20200101T100000Z
+      LAST-MODIFIED:20200101T100000Z
       DTSTART:29990102T103000Z
       DTEND:29990102T120000Z
       RECURRENCE-ID:29990102T100000Z
@@ -342,8 +348,9 @@ describe('createIcsFile', () => {
       PRODID:-//nordeck.net//matrix-meetings//EN
       BEGIN:VEVENT
       UID:!meeting-room-id-entry-0
-      SEQUENCE:0
+      SEQUENCE:1577872800
       DTSTAMP:20200101T100000Z
+      LAST-MODIFIED:20200101T100000Z
       DTSTART:29990101T100000Z
       DTEND:29990101T140000Z
       RRULE:FREQ=DAILY
@@ -442,8 +449,9 @@ describe('createIcsFile', () => {
       END:VTIMEZONE
       BEGIN:VEVENT
       UID:!meeting-room-id-entry-0
-      SEQUENCE:0
+      SEQUENCE:1577872800
       DTSTAMP:20200101T100000Z
+      LAST-MODIFIED:20200101T100000Z
       DTSTART;TZID=Europe/Berlin:29990101T100000
       DTEND:29990101T140000Z
       RRULE:FREQ=DAILY
@@ -454,8 +462,9 @@ describe('createIcsFile', () => {
       END:VEVENT
       BEGIN:VEVENT
       UID:!meeting-room-id-entry-0
-      SEQUENCE:0
+      SEQUENCE:1577872800
       DTSTAMP:20200101T100000Z
+      LAST-MODIFIED:20200101T100000Z
       DTSTART;TZID=Europe/London:29990104T103000
       DTEND;TZID=Europe/Moscow:29990104T150000
       RECURRENCE-ID;TZID=Europe/Moscow:29990104T130000
@@ -499,8 +508,9 @@ describe('createIcsFile', () => {
       PRODID:-//nordeck.net//matrix-meetings//EN
       BEGIN:VEVENT
       UID:!meeting-room-id-entry-0
-      SEQUENCE:0
+      SEQUENCE:1577872800
       DTSTAMP:20200101T100000Z
+      LAST-MODIFIED:20200101T100000Z
       DTSTART:29990101T100000Z
       DTEND:29990101T140000Z
       SUMMARY:An important meeting
@@ -509,8 +519,9 @@ describe('createIcsFile', () => {
       END:VEVENT
       BEGIN:VEVENT
       UID:!meeting-room-id-entry-1
-      SEQUENCE:0
+      SEQUENCE:1577872800
       DTSTAMP:20200101T100000Z
+      LAST-MODIFIED:20200101T100000Z
       DTSTART:29990102T100000Z
       DTEND:29990102T140000Z
       SUMMARY:An important meeting
@@ -555,8 +566,9 @@ describe('createIcsFile', () => {
       PRODID:-//nordeck.net//matrix-meetings//EN
       BEGIN:VEVENT
       UID:!meeting-room-id-entry-0
-      SEQUENCE:0
+      SEQUENCE:1577872800
       DTSTAMP:20200101T100000Z
+      LAST-MODIFIED:20200101T100000Z
       DTSTART:29990101T100000Z
       DTEND:29990101T140000Z
       RRULE:FREQ=DAILY;UNTIL=20200110T235959Z
@@ -566,8 +578,9 @@ describe('createIcsFile', () => {
       END:VEVENT
       BEGIN:VEVENT
       UID:!meeting-room-id-entry-1
-      SEQUENCE:0
+      SEQUENCE:1577872800
       DTSTAMP:20200101T100000Z
+      LAST-MODIFIED:20200101T100000Z
       DTSTART:29990111T100000Z
       DTEND:29990111T140000Z
       RRULE:FREQ=WEEKLY

--- a/matrix-meetings-widget/src/components/meetings/MeetingCardShareMeetingContent/useDownloadIcsFile.ts
+++ b/matrix-meetings-widget/src/components/meetings/MeetingCardShareMeetingContent/useDownloadIcsFile.ts
@@ -123,8 +123,9 @@ export function createIcsFile({
   for (const calendarEntry of meetingCalendar) {
     g += 'BEGIN:VEVENT\r\n';
     g += `UID:${meeting.meetingId}-${calendarEntry.uid}\r\n`;
-    g += 'SEQUENCE:0\r\n';
+    g += `SEQUENCE:${DateTime.now().toUnixInteger()}\r\n`;
     g += `DTSTAMP:${formatICalDate(DateTime.now(), 'UTC').value}Z\r\n`;
+    g += `LAST-MODIFIED:${formatICalDate(DateTime.now(), 'UTC').value}Z\r\n`;
     g += writeDateProperty('DTSTART', calendarEntry.dtstart);
     g += writeDateProperty('DTEND', calendarEntry.dtend);
     if (calendarEntry.rrule) {

--- a/matrix-meetings-widget/src/components/meetings/MeetingCardShareMeetingContent/useDownloadIcsFile.ts
+++ b/matrix-meetings-widget/src/components/meetings/MeetingCardShareMeetingContent/useDownloadIcsFile.ts
@@ -14,13 +14,17 @@
  * limitations under the License.
  */
 
-import ical from 'ical-generator';
-import { isArray } from 'lodash';
+import { isArray, uniq } from 'lodash';
 import { DateTime } from 'luxon';
 import { useEffect, useMemo, useState } from 'react';
 import { tzlib_get_ical_block } from 'timezones-ical-library';
-import { parseICalDate } from '../../../lib/utils';
-import { Meeting } from '../../../reducer/meetingsApi';
+import { CalendarEntry, DateTimeEntry } from '../../../lib/matrix';
+import { formatICalDate, isDefined, parseICalDate } from '../../../lib/utils';
+import {
+  Meeting,
+  selectNordeckMeetingMetadataEventByRoomId,
+} from '../../../reducer/meetingsApi';
+import { useAppSelector } from '../../../store';
 import { useMeetingEmail } from './useMeetingEmail';
 import { useMeetingUrl } from './useMeetingUrl';
 
@@ -34,6 +38,10 @@ export function useDownloadIcsFile(meeting: Meeting): UseDownloadIcsFile {
   const { url } = useMeetingUrl(meeting);
   const { message } = useMeetingEmail(meeting);
 
+  const metadataEvent = useAppSelector((state) =>
+    selectNordeckMeetingMetadataEventByRoomId(state, meeting.meetingId),
+  );
+
   const filename = useMemo(
     () =>
       `${meeting.title}_${DateTime.fromISO(meeting.startTime).toFormat(
@@ -45,7 +53,12 @@ export function useDownloadIcsFile(meeting: Meeting): UseDownloadIcsFile {
   const [blobUrl, setBlobUrl] = useState<string | undefined>();
 
   useEffect(() => {
-    const value = createIcsFile(meeting, url, message);
+    const value = createIcsFile({
+      meeting,
+      meetingCalendar: metadataEvent?.content.calendar ?? [],
+      meetingUrl: url,
+      message,
+    });
 
     if (value) {
       const blob = new Blob([value]);
@@ -61,7 +74,7 @@ export function useDownloadIcsFile(meeting: Meeting): UseDownloadIcsFile {
     }
 
     return () => {};
-  }, [meeting, message, url]);
+  }, [meeting, message, metadataEvent?.content.calendar, url]);
 
   return useMemo(
     () => ({
@@ -73,41 +86,69 @@ export function useDownloadIcsFile(meeting: Meeting): UseDownloadIcsFile {
   );
 }
 
-export function createIcsFile(
-  meeting: Meeting,
-  meetingUrl: string,
-  message: string,
-): string | undefined {
-  const cal = ical();
+export function createIcsFile({
+  meeting,
+  meetingCalendar,
+  meetingUrl,
+  message,
+}: {
+  meeting: Meeting;
+  meetingCalendar: CalendarEntry[];
+  meetingUrl: string;
+  message: string;
+}): string | undefined {
+  const allTimezones = uniq(
+    meetingCalendar
+      .flatMap((c) => [
+        c.dtstart.tzid,
+        c.dtend.tzid,
+        c.recurrenceId?.tzid,
+        // exdates will be added as UTC so we don't need to consider their timezones
+      ])
+      .filter((c) => c !== 'UTC')
+      .filter(isDefined),
+  );
+  const tzStrings = allTimezones.map(generateVTimezone).filter(isDefined);
 
-  // TODO: consider all entries (incl recurrenceId and exdate)
+  let g = '';
 
-  if (meeting.calendarEntries[0].dtstart.tzid !== 'UTC') {
-    cal.timezone({
-      name: meeting.calendarEntries[0].dtstart.tzid,
-      generator: generateVTimezone,
-    });
+  g += 'BEGIN:VCALENDAR\r\n';
+  g += 'VERSION:2.0\r\n';
+  g += `PRODID:-//nordeck.net//matrix-meetings//EN\r\n`;
+
+  for (const tzString of tzStrings) {
+    g += tzString.replace(/\r\n/g, '\n').replace(/\n/g, '\r\n').trim() + '\r\n';
   }
 
-  cal.createEvent({
-    id: `${meeting.meetingId}-${meeting.calendarUid}`,
-    summary: meeting.title,
-    stamp: DateTime.now(),
-    description: message,
-    start: parseICalDate(meeting.calendarEntries[0].dtstart),
-    end: parseICalDate(meeting.calendarEntries[0].dtend),
-    location: meetingUrl,
-    repeating: meeting.calendarEntries[0].rrule
-      ? `RRULE:${meeting.calendarEntries[0].rrule}`
-      : undefined,
-    // TODO: Add recurrenceId
-    // TODO: Add exdate
-    timezone: meeting.calendarEntries[0].dtstart.tzid,
-    // TODO: the url field is not supported everywhere and will create errors
-    // TODO: attendees can only be added if the email is known
-  });
+  for (const calendarEntry of meetingCalendar) {
+    g += 'BEGIN:VEVENT\r\n';
+    g += `UID:${meeting.meetingId}-${calendarEntry.uid}\r\n`;
+    g += 'SEQUENCE:0\r\n';
+    g += `DTSTAMP:${formatICalDate(DateTime.now(), 'UTC').value}Z\r\n`;
+    g += writeDateProperty('DTSTART', calendarEntry.dtstart);
+    g += writeDateProperty('DTEND', calendarEntry.dtend);
+    if (calendarEntry.rrule) {
+      g += `RRULE:${calendarEntry.rrule}\r\n`;
+    }
+    if (calendarEntry.recurrenceId) {
+      g += writeDateProperty('RECURRENCE-ID', calendarEntry.recurrenceId);
+    }
+    if (calendarEntry.exdate && calendarEntry.exdate.length > 0) {
+      const exdates = calendarEntry.exdate.map(
+        // We add the exdates in UTC
+        (ex) => `${formatICalDate(parseICalDate(ex), 'UTC').value}Z`,
+      );
+      g += `EXDATE:${exdates}\r\n`;
+    }
+    g += `SUMMARY:${escape(meeting.title, false)}\r\n`;
+    g += `LOCATION:${escape(meetingUrl, false)}\r\n`;
+    g += `DESCRIPTION:${escape(message, false)}\r\n`;
+    g += 'END:VEVENT\r\n';
+  }
 
-  return cal.toString();
+  g += 'END:VCALENDAR';
+
+  return foldLines(g);
 }
 
 export function generateVTimezone(timezone: string): string | null {
@@ -118,4 +159,62 @@ export function generateVTimezone(timezone: string): string | null {
   }
 
   return null;
+}
+
+function writeDateProperty(
+  property: string,
+  dateTimeEntry: DateTimeEntry,
+): string {
+  if (dateTimeEntry.tzid === 'UTC') {
+    return `${property}:${dateTimeEntry.value}Z\r\n`;
+  } else {
+    return `${property};TZID=${dateTimeEntry.tzid}:${dateTimeEntry.value}\r\n`;
+  }
+}
+
+/**
+ * Escapes special characters in the given string
+ *
+ * Based on https://github.com/sebbo2002/ical-generator/blob/71a354b597219ac8209caf341571c25418fc2690/src/tools.ts
+ */
+export function escape(str: string | unknown, inQuotes: boolean): string {
+  return String(str)
+    .replace(inQuotes ? /[\\"]/g : /[\\;,]/g, function (match) {
+      return '\\' + match;
+    })
+    .replace(/(?:\r\n|\r|\n)/g, '\\n');
+}
+
+/**
+ * Trim line length of given string
+ *
+ * Based on https://github.com/sebbo2002/ical-generator/blob/71a354b597219ac8209caf341571c25418fc2690/src/tools.ts
+ */
+export function foldLines(input: string): string {
+  return input
+    .split('\r\n')
+    .map(function (line) {
+      let result = '';
+      let c = 0;
+      for (let i = 0; i < line.length; i++) {
+        let ch = line.charAt(i);
+
+        // surrogate pair, see https://mathiasbynens.be/notes/javascript-encoding#surrogate-pairs
+        if (ch >= '\ud800' && ch <= '\udbff') {
+          ch += line.charAt(++i);
+        }
+
+        // TextEncoder is available in browsers and node.js >= 11.0.0
+        const charsize = new TextEncoder().encode(ch).length;
+        c += charsize;
+        if (c > 74) {
+          result += '\r\n ';
+          c = charsize;
+        }
+
+        result += ch;
+      }
+      return result;
+    })
+    .join('\r\n');
 }

--- a/matrix-meetings-widget/src/lib/utils/dateTimeUtils.test.ts
+++ b/matrix-meetings-widget/src/lib/utils/dateTimeUtils.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { DateTime } from 'luxon';
+import { mockDateTimeFormatTimeZone } from '../../timezoneMockUtils';
 import { mockMeeting } from '../testUtils';
 import {
   formatICalDate,
@@ -117,8 +118,22 @@ describe('toISOString', () => {
     );
   });
 
+  it('should format javascript Date in another timezone', () => {
+    mockDateTimeFormatTimeZone('Europe/Berlin');
+    expect(toISOString(new Date('2022-10-29T09:00:00+01:00'))).toBe(
+      '2022-10-29T08:00:00Z',
+    );
+  });
+
   it('should format luxon DateTime', () => {
     expect(toISOString(DateTime.fromISO('2022-10-29T08:00:00Z'))).toBe(
+      '2022-10-29T08:00:00Z',
+    );
+  });
+
+  it('should format luxon DateTime in another timezone', () => {
+    mockDateTimeFormatTimeZone('Europe/Berlin');
+    expect(toISOString(DateTime.fromISO('2022-10-29T09:00:00+01:00'))).toBe(
       '2022-10-29T08:00:00Z',
     );
   });

--- a/matrix-meetings-widget/src/lib/utils/dateTimeUtils.ts
+++ b/matrix-meetings-widget/src/lib/utils/dateTimeUtils.ts
@@ -49,7 +49,8 @@ export function formatICalDate(
   };
 }
 
+/** Format the date into an ISO string that will always be in UTC time (yyyy-MM-ddTHH:mm:ssZ) */
 export function toISOString(date: Date | DateTime): string {
   const jsDate = DateTime.isDateTime(date) ? date : DateTime.fromJSDate(date);
-  return jsDate.toISO({ suppressMilliseconds: true });
+  return jsDate.toUTC().toISO({ suppressMilliseconds: true });
 }

--- a/matrix-meetings-widget/src/lib/utils/isDefined.ts
+++ b/matrix-meetings-widget/src/lib/utils/isDefined.ts
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-export function isDefined<T>(v: T | undefined): v is T {
-  return v !== undefined;
+export function isDefined<T>(v: T | undefined | null): v is T {
+  return v !== undefined && v !== null;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7502,13 +7502,6 @@ i18next@^23.4.4, i18next@^23.4.5:
   dependencies:
     "@babel/runtime" "^7.22.5"
 
-ical-generator@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/ical-generator/-/ical-generator-5.0.1.tgz#10ddb463e8716511a9cf0463de9ba57d365c900c"
-  integrity sha512-ln2cbzi+Z+f9WrWseU4B75Ccwb2hMpgjTYkriSPmqODmOCWNYknTSWiLSrCkl0cHiWcwaTWstMPLDyiFbELmoA==
-  dependencies:
-    uuid-random "^1.3.2"
-
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -13315,11 +13308,6 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
-
-uuid-random@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/uuid-random/-/uuid-random-1.3.2.tgz#96715edbaef4e84b1dcf5024b00d16f30220e2d0"
-  integrity sha512-UOzej0Le/UgkbWEO8flm+0y+G+ljUon1QWTEZOq1rnMAsxo2+SckbiZdKzAHHlVh6gJqI1TjC/xwgR50MuCrBQ==
 
 uuid@9.0.0:
   version "9.0.0"


### PR DESCRIPTION
This PR removes the `ical-generator` library since it was not flexible enough for our use case. Our data model already stores the dates and times according to the iCalendar standard, so we can easily generate the file based on the data that we already have.

Testing this requires #271 and #281 to be merge first.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [x] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
