### PR TITLE
Add missing invitation text when user is invited into existing meeting

### DIFF
--- a/.changeset/poor-apples-turn.md
+++ b/.changeset/poor-apples-turn.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-meetings-bot': patch
+---
+
+Add missing invitation text when user is invited into existing meeting

--- a/matrix-meetings-bot/test/MeetingService.test.ts
+++ b/matrix-meetings-bot/test/MeetingService.test.ts
@@ -1011,7 +1011,7 @@ describe('test relevant functionality of MeetingService', () => {
     ).toEqual(['44444']);
   });
 
-  test.only('should invite users', async () => {
+  test('should invite users', async () => {
     const roomId = 'a1';
 
     const roomCreationEvent: IStateEvent<any> = {


### PR DESCRIPTION
This PR fixes the issue that invitation text doesn't contain meeting details when user is added (invited) into existing meeting.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [x] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
