### PR TITLE
Change power level of the guest users

### DIFF
--- a/.changeset/old-dolls-trade.md
+++ b/.changeset/old-dolls-trade.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-meetings-bot': minor
+---
+
+Change power level of the guest users

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -131,6 +131,19 @@ JITSI_PIN_URL=
 
 # optional - configure a Open-Xchange link that can be used to open the calendar room in their calendar application. use the {{id}} and {{folder}} as a template parameter (ex: "http://ox.example.com/appsuite/#app=io.ox/calendar&id={{id}}&folder={{folder}}")
 OPEN_XCHANGE_MEETING_URL_TEMPLATE=
+
+# optional - enables changing of power level of the guest users when they join the room. This case also requires that the user's default power level that be higher then guest user power level and that the bot has rights to change power levels, otherwise no change occurs.
+ENABLE_GUEST_USER_POWER_LEVEL_CHANGE=false
+
+# optional - configure guest user id prefix that is used to match guest users.
+GUEST_USER_ID_PREFIX=guest-
+
+# optional - configure guest user power level
+GUEST_USER_DEFAULT_POWER_LEVEL=0
+
+# optional - if true, bot deletes guest user power level from power level event when guest user leaves the room. It makes sure power level is cleaned up if guest user is deactivated later.
+GUEST_USER_DELETE_POWER_LEVEL_ON_LEAVE=true
+#
 ```
 
 #### `DEFAULT_EVENTS_CONFIG`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -136,7 +136,7 @@ OPEN_XCHANGE_MEETING_URL_TEMPLATE=
 ENABLE_GUEST_USER_POWER_LEVEL_CHANGE=false
 
 # optional - configure guest user id prefix that is used to match guest users.
-GUEST_USER_ID_PREFIX=guest-
+GUEST_USER_PREFIX=@guest-
 
 # optional - configure guest user power level
 GUEST_USER_DEFAULT_POWER_LEVEL=0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -132,7 +132,7 @@ JITSI_PIN_URL=
 # optional - configure a Open-Xchange link that can be used to open the calendar room in their calendar application. use the {{id}} and {{folder}} as a template parameter (ex: "http://ox.example.com/appsuite/#app=io.ox/calendar&id={{id}}&folder={{folder}}")
 OPEN_XCHANGE_MEETING_URL_TEMPLATE=
 
-# optional - enables changing of power level of the guest users when they join the room. This case also requires that the user's default power level that be higher then guest user power level and that the bot has rights to change power levels, otherwise no change occurs.
+# optional - enables changing of power level of the guest users when they join the room. This case requires that the user's default power level is higher than the guest user's and that the bot has rights to change power levels, otherwise no change occurs.
 ENABLE_GUEST_USER_POWER_LEVEL_CHANGE=false
 
 # optional - configure guest user id prefix that is used to match guest users.

--- a/e2e/src/deploy/matrixMeetingsBot/default_events.json
+++ b/e2e/src/deploy/matrixMeetingsBot/default_events.json
@@ -3,6 +3,7 @@
     {
       "type": "m.room.power_levels",
       "content": {
+        "users_default": 25,
         "events": {
           "net.nordeck.meetings.metadata": 100
         }

--- a/e2e/src/deploy/matrixMeetingsBot/index.ts
+++ b/e2e/src/deploy/matrixMeetingsBot/index.ts
@@ -59,6 +59,7 @@ export async function startMatrixMeetingsBot({
       OPEN_XCHANGE_MEETING_URL_TEMPLATE:
         'https://webmail-hostname/appsuite/#app=io.ox/calendar&id={{id}}&folder={{folder}}',
       AUTO_DELETION_OFFSET: '60',
+      ENABLE_GUEST_USER_POWER_LEVEL_CHANGE: 'true',
       LOG_LEVEL: 'debug',
     })
     .withCopyFilesToContainer([

--- a/e2e/src/pages/elementWebPage.ts
+++ b/e2e/src/pages/elementWebPage.ts
@@ -297,6 +297,40 @@ export class ElementWebPage {
       .toEqual(membership);
   }
 
+  async waitForUserPowerLevel(
+    username: string,
+    powerLevel: number | undefined,
+  ): Promise<void> {
+    await expect
+      .poll(
+        async () => {
+          const roomId = this.getCurrentRoomId();
+
+          return await this.page.evaluate(
+            async ({ roomId, username }) => {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const client = (window as any).mxMatrixClientPeg.get();
+
+              try {
+                const powerLevels = await client.getStateEvent(
+                  roomId,
+                  'm.room.power_levels',
+                  '',
+                );
+
+                return powerLevels.users?.[`@${username}:localhost`];
+              } catch (err) {
+                return 'error';
+              }
+            },
+            { roomId, username },
+          );
+        },
+        { timeout: 60000 },
+      )
+      .toEqual(powerLevel);
+  }
+
   async removeUser(username: string) {
     const roomId = this.getCurrentRoomId();
 

--- a/e2e/src/scheduleMeeting.spec.ts
+++ b/e2e/src/scheduleMeeting.spec.ts
@@ -200,4 +200,49 @@ test.describe('Schedule Meeting', () => {
     await bobElementWebPage.joinRoom();
     await expect(bobJitsiWidgetPage.joinConferenceButton).toBeVisible();
   });
+
+  test('should invite the guest user via a link and kick', async ({
+    aliceElementWebPage,
+    aliceMeetingsWidgetPage,
+    guest,
+    guestPage,
+    guestElementWebPage,
+    guestJitsiWidgetPage,
+  }) => {
+    await aliceMeetingsWidgetPage.setDateFilter([2040, 10, 1], [2040, 10, 8]);
+    const aliceScheduleMeetingWidgetPage =
+      await aliceMeetingsWidgetPage.scheduleMeeting();
+
+    await aliceScheduleMeetingWidgetPage.titleTextbox.fill('My Meeting');
+    await aliceScheduleMeetingWidgetPage.descriptionTextbox.fill(
+      'My Description',
+    );
+    await aliceScheduleMeetingWidgetPage.setStart([2040, 10, 3], '10:30 AM');
+    await aliceScheduleMeetingWidgetPage.submit();
+
+    const aliceMeeting = aliceMeetingsWidgetPage.getMeeting(
+      'My Meeting',
+      '10/03/2040',
+    );
+
+    await expect(aliceMeeting.meetingTimeRangeText).toHaveText(
+      '10:30 AM – 11:30 AM',
+    );
+
+    await aliceMeeting.switchToShareMeeting();
+    await aliceElementWebPage.approveWidgetIdentity();
+    const meetingLink = await aliceMeeting.getShareLink();
+
+    await guestPage.goto(meetingLink);
+    await guestElementWebPage.joinRoom();
+    await expect(guestJitsiWidgetPage.joinConferenceButton).toBeVisible();
+
+    await aliceElementWebPage.switchToRoom('My Meeting');
+
+    await aliceElementWebPage.waitForUserPowerLevel(guest.username, 0);
+
+    await aliceElementWebPage.removeUser(guest.username);
+
+    await aliceElementWebPage.waitForUserPowerLevel(guest.username, undefined);
+  });
 });

--- a/matrix-meetings-bot/src/IAppConfiguration.ts
+++ b/matrix-meetings-bot/src/IAppConfiguration.ts
@@ -56,7 +56,7 @@ export interface IAppConfiguration {
   matrix_filter_timeline_limit: number;
 
   enable_guest_user_power_level_change: boolean;
-  guest_user_id_prefix: string;
+  guest_user_prefix: string;
   guest_user_default_power_level: number;
   guest_user_delete_power_level_on_leave: boolean;
 }

--- a/matrix-meetings-bot/src/IAppConfiguration.ts
+++ b/matrix-meetings-bot/src/IAppConfiguration.ts
@@ -54,4 +54,9 @@ export interface IAppConfiguration {
 
   matrix_filter_apply: boolean;
   matrix_filter_timeline_limit: number;
+
+  enable_guest_user_power_level_change: boolean;
+  guest_user_id_prefix: string;
+  guest_user_default_power_level: number;
+  guest_user_delete_power_level_on_leave: boolean;
 }

--- a/matrix-meetings-bot/src/app.module.ts
+++ b/matrix-meetings-bot/src/app.module.ts
@@ -45,6 +45,7 @@ import { WidgetClient } from './client/WidgetClient';
 import configuration, { ValidationSchema } from './configuration';
 import { CommandController } from './controller/CommandController';
 import { ConfigurationController } from './controller/ConfigurationController';
+import { GuestMemberController } from './controller/GuestMemberController';
 import { HealthCheckController } from './controller/HealthCheckController';
 import { MeetingController } from './controller/MeetingController';
 import { WelcomeWorkflowController } from './controller/WelcomeWorkflowController';
@@ -62,6 +63,7 @@ import { IRoomMatrixEvents } from './model/IRoomMatrixEvents';
 import { MatrixServer } from './rpc/MatrixServer';
 import { CommandService } from './service/CommandService';
 import { ControlRoomMigrationService } from './service/ControlRoomMigrationService';
+import { GuestMemberService } from './service/GuestMemberService';
 import { MeetingService } from './service/MeetingService';
 import { RoomMessageService } from './service/RoomMessageService';
 import { WelcomeWorkflowService } from './service/WelcomeWorkflowService';
@@ -219,6 +221,7 @@ const i18nFactory: FactoryProvider<void> = {
     MeetingController,
     WelcomeWorkflowController,
     WidgetController,
+    GuestMemberController,
   ],
 
   providers: [
@@ -241,6 +244,7 @@ const i18nFactory: FactoryProvider<void> = {
     WidgetLayoutService,
     MatrixServer,
     DoesWidgetWithIdExistConstraint,
+    GuestMemberService,
   ],
 })
 export class AppModule implements NestModule {

--- a/matrix-meetings-bot/src/configuration.ts
+++ b/matrix-meetings-bot/src/configuration.ts
@@ -108,7 +108,7 @@ function createConfiguration() {
       process.env.ENABLE_GUEST_USER_POWER_LEVEL_CHANGE,
       false,
     ),
-    guest_user_id_prefix: process.env.GUEST_USER_ID_PREFIX || 'guest-',
+    guest_user_prefix: process.env.GUEST_USER_PREFIX || '@guest-',
     guest_user_default_power_level:
       Number(process.env.GUEST_USER_DEFAULT_POWER_LEVEL) || 0,
     guest_user_delete_power_level_on_leave: toBoolean(
@@ -176,7 +176,7 @@ export const ValidationSchema = Joi.object({
   ),
 
   ENABLE_GUEST_USER_POWER_LEVEL_CHANGE: Joi.boolean(),
-  GUEST_USER_ID_PREFIX: Joi.string(),
+  GUEST_USER_PREFIX: Joi.string(),
   GUEST_USER_DEFAULT_POWER_LEVEL: Joi.number(),
   GUEST_USER_DELETE_POWER_LEVEL_ON_LEAVE: Joi.boolean(),
 });

--- a/matrix-meetings-bot/src/configuration.ts
+++ b/matrix-meetings-bot/src/configuration.ts
@@ -103,6 +103,18 @@ function createConfiguration() {
       process.env.MATRIX_FILTER_TIMELINE_LIMIT,
       50,
     ),
+
+    enable_guest_user_power_level_change: toBoolean(
+      process.env.ENABLE_GUEST_USER_POWER_LEVEL_CHANGE,
+      false,
+    ),
+    guest_user_id_prefix: process.env.GUEST_USER_ID_PREFIX || 'guest-',
+    guest_user_default_power_level:
+      Number(process.env.GUEST_USER_DEFAULT_POWER_LEVEL) || 0,
+    guest_user_delete_power_level_on_leave: toBoolean(
+      process.env.GUEST_USER_DELETE_POWER_LEVEL_ON_LEAVE,
+      true,
+    ),
   };
 
   return {
@@ -162,6 +174,11 @@ export const ValidationSchema = Joi.object({
     'trace',
     'silent',
   ),
+
+  ENABLE_GUEST_USER_POWER_LEVEL_CHANGE: Joi.boolean(),
+  GUEST_USER_ID_PREFIX: Joi.string(),
+  GUEST_USER_DEFAULT_POWER_LEVEL: Joi.number(),
+  GUEST_USER_DELETE_POWER_LEVEL_ON_LEAVE: Joi.boolean(),
 });
 
 export default createConfiguration;

--- a/matrix-meetings-bot/src/controller/GuestMemberController.ts
+++ b/matrix-meetings-bot/src/controller/GuestMemberController.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Controller, UseFilters } from '@nestjs/common';
+import { EventPattern, Payload } from '@nestjs/microservices';
+import { MembershipEventContent } from 'matrix-bot-sdk';
+import { RoomIdParam } from '../decorator/RoomIdParam';
+import { WebExceptionFilter } from '../filter/WebExceptionFilter';
+import { IStateEvent } from '../matrix/event/IStateEvent';
+import { StateEventName } from '../model/StateEventName';
+import { matrixPattern } from '../rpc/IMatrixPattern';
+import { GuestMemberService } from '../service/GuestMemberService';
+
+@Controller()
+@UseFilters(WebExceptionFilter)
+export class GuestMemberController {
+  constructor(private guestWorkflowService: GuestMemberService) {}
+
+  @EventPattern(matrixPattern.roomEvent(StateEventName.M_ROOM_MEMBER_EVENT))
+  async member(
+    @RoomIdParam() roomId: string,
+    @Payload() event: IStateEvent<MembershipEventContent>,
+  ) {
+    await this.guestWorkflowService.processMember(roomId, event);
+  }
+}

--- a/matrix-meetings-bot/src/service/GuestMemberService.ts
+++ b/matrix-meetings-bot/src/service/GuestMemberService.ts
@@ -52,7 +52,7 @@ export class GuestMemberService {
 
     const {
       enable_guest_user_power_level_change,
-      guest_user_id_prefix,
+      guest_user_prefix,
       guest_user_default_power_level,
       guest_user_delete_power_level_on_leave,
     } = this.appConfiguration;
@@ -61,7 +61,7 @@ export class GuestMemberService {
 
     const memberEventMatches =
       enable_guest_user_power_level_change &&
-      memberEvent.state_key.startsWith('@' + guest_user_id_prefix) &&
+      memberEvent.state_key.startsWith(guest_user_prefix) &&
       (membership === 'join' || membership === 'leave');
 
     if (!memberEventMatches) {

--- a/matrix-meetings-bot/src/service/GuestMemberService.ts
+++ b/matrix-meetings-bot/src/service/GuestMemberService.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2023 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  MatrixClient,
+  MembershipEventContent,
+  PowerLevelsEventContent,
+} from 'matrix-bot-sdk';
+import { AppRuntimeContext } from '../AppRuntimeContext';
+import { IAppConfiguration } from '../IAppConfiguration';
+import { ModuleProviderToken } from '../ModuleProviderToken';
+import { IStateEvent } from '../matrix/event/IStateEvent';
+import { StateEventName } from '../model/StateEventName';
+
+@Injectable()
+export class GuestMemberService {
+  constructor(
+    private appRuntimeContext: AppRuntimeContext,
+    @Inject(ModuleProviderToken.APP_CONFIGURATION)
+    private appConfiguration: IAppConfiguration,
+    private matrixClient: MatrixClient,
+  ) {}
+
+  /**
+   * Changes power level of the guest user who joins or leaves the room with the bot if the following is true:
+   *  - guest user power level change is enabled
+   *  - the default guest user power level is lower than the default user power level
+   *  - bot is allowed to change power levels
+   *
+   * @param roomId room id
+   * @param memberEvent member event
+   */
+  public async processMember(
+    roomId: string,
+    memberEvent: IStateEvent<MembershipEventContent>,
+  ) {
+    const { botUserId } = this.appRuntimeContext;
+
+    const {
+      enable_guest_user_power_level_change,
+      guest_user_id_prefix,
+      guest_user_default_power_level,
+      guest_user_delete_power_level_on_leave,
+    } = this.appConfiguration;
+
+    const membership = memberEvent.content.membership;
+
+    const memberEventMatches =
+      enable_guest_user_power_level_change &&
+      memberEvent.state_key.startsWith('@' + guest_user_id_prefix) &&
+      (membership === 'join' || membership === 'leave');
+
+    if (!memberEventMatches) {
+      return;
+    }
+
+    let powerLevels: PowerLevelsEventContent | undefined;
+
+    try {
+      powerLevels = await this.matrixClient.getRoomStateEvent(
+        roomId,
+        StateEventName.M_ROOM_POWER_LEVELS_EVENT,
+        '',
+      );
+    } catch (err) {
+      powerLevels = undefined;
+    }
+
+    if (!powerLevels) {
+      return;
+    }
+
+    const usersDefaultPower = powerLevels.users_default ?? 0;
+    const botPower = powerLevels.users?.[botUserId] ?? usersDefaultPower;
+
+    const powerLevelsPower =
+      powerLevels.events?.['m.room.power_levels'] ??
+      powerLevels.state_default ??
+      50;
+
+    const powerLevelsMatch =
+      usersDefaultPower > guest_user_default_power_level &&
+      botPower >= powerLevelsPower;
+
+    if (!powerLevelsMatch) {
+      return;
+    }
+
+    let newPowerLevels: PowerLevelsEventContent | undefined;
+
+    if (
+      membership === 'join' &&
+      powerLevels.users?.[memberEvent.state_key] === undefined
+    ) {
+      newPowerLevels = {
+        ...powerLevels,
+        users: {
+          ...(powerLevels.users ?? {}),
+          [memberEvent.state_key]: guest_user_default_power_level,
+        },
+      };
+    } else if (
+      guest_user_delete_power_level_on_leave &&
+      membership === 'leave' &&
+      powerLevels.users?.[memberEvent.state_key] !== undefined
+    ) {
+      newPowerLevels = { ...powerLevels };
+      delete newPowerLevels.users![memberEvent.state_key];
+    }
+
+    if (newPowerLevels) {
+      await this.matrixClient.sendStateEvent(
+        roomId,
+        StateEventName.M_ROOM_POWER_LEVELS_EVENT,
+        '',
+        newPowerLevels,
+      );
+    }
+  }
+}

--- a/matrix-meetings-bot/test/GuestMemberService.test.ts
+++ b/matrix-meetings-bot/test/GuestMemberService.test.ts
@@ -1,0 +1,501 @@
+/*
+ * Copyright 2023 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  MatrixClient,
+  MembershipEventContent,
+  PowerLevelsEventContent,
+} from 'matrix-bot-sdk';
+import { capture, instance, mock, when } from 'ts-mockito';
+import { AppRuntimeContext } from '../src/AppRuntimeContext';
+import { IAppConfiguration } from '../src/IAppConfiguration';
+import { IStateEvent } from '../src/matrix/event/IStateEvent';
+import { StateEventName } from '../src/model/StateEventName';
+import { GuestMemberService } from '../src/service/GuestMemberService';
+import { createAppConfig, getArgsFromCaptor } from './util/MockUtils';
+
+describe('GuestMemberService', () => {
+  const botUserId = '@bot:matrix.org';
+  const roomId = '!roomId1';
+
+  const appRuntimeContext: AppRuntimeContext = {
+    botUserId,
+    displayName: '',
+    localpart: '',
+    supportedLngs: [],
+  };
+
+  let appConfig: IAppConfiguration;
+
+  let matrixClientMock: MatrixClient;
+  let matrixClient: MatrixClient;
+  let guestMemberService: GuestMemberService;
+
+  beforeEach(() => {
+    appConfig = {
+      ...createAppConfig(),
+      enable_guest_user_power_level_change: true,
+    };
+
+    matrixClientMock = mock(MatrixClient);
+    matrixClient = instance(matrixClientMock);
+    guestMemberService = new GuestMemberService(
+      appRuntimeContext,
+      appConfig,
+      matrixClient,
+    );
+  });
+
+  test.each([50, 100, 101])(
+    'assigns power level to guest when guest joins and bot has power (power level: %s)',
+    async (botPowerLevel) => {
+      when(
+        matrixClientMock.getRoomStateEvent(
+          roomId,
+          StateEventName.M_ROOM_POWER_LEVELS_EVENT,
+          '',
+        ),
+      ).thenResolve({
+        users: {
+          [botUserId]: botPowerLevel,
+        },
+        users_default: 25,
+        events: {},
+        events_default: 0,
+        state_default: 50,
+        ban: 50,
+        kick: 50,
+        redact: 50,
+        invite: 0,
+      } satisfies PowerLevelsEventContent);
+
+      const memberEvent: IStateEvent<MembershipEventContent> = {
+        event_id: '$eventId1',
+        origin_server_ts: Date.now(),
+        sender: '@guest-userId1:matrix.org',
+        type: StateEventName.M_ROOM_MEMBER_EVENT,
+        content: {
+          membership: 'join',
+        },
+        state_key: '@guest-userId1:matrix.org',
+      };
+      await guestMemberService.processMember(roomId, memberEvent);
+
+      expect(
+        getArgsFromCaptor(capture(matrixClientMock.sendStateEvent)).map(
+          ([, , , content]) => content,
+        ),
+      ).toEqual([
+        {
+          users: {
+            [botUserId]: botPowerLevel,
+            '@guest-userId1:matrix.org': 0,
+          },
+          users_default: 25,
+          events: {},
+          events_default: 0,
+          state_default: 50,
+          ban: 50,
+          kick: 50,
+          redact: 50,
+          invite: 0,
+        },
+      ]);
+    },
+  );
+
+  test.each([50, 100, 101])(
+    'deletes power level of guest when guest leaves and bot has power (power level: %s)',
+    async (botPowerLevel) => {
+      when(
+        matrixClientMock.getRoomStateEvent(
+          roomId,
+          StateEventName.M_ROOM_POWER_LEVELS_EVENT,
+          '',
+        ),
+      ).thenResolve({
+        users: {
+          [botUserId]: botPowerLevel,
+          '@guest-userId1:matrix.org': 0,
+        },
+        users_default: 25,
+        events: {},
+        events_default: 0,
+        state_default: 50,
+        ban: 50,
+        kick: 50,
+        redact: 50,
+        invite: 0,
+      } satisfies PowerLevelsEventContent);
+
+      const memberEvent: IStateEvent<MembershipEventContent> = {
+        event_id: '$eventId1',
+        origin_server_ts: Date.now(),
+        sender: '@guest-userId1:matrix.org',
+        type: StateEventName.M_ROOM_MEMBER_EVENT,
+        content: {
+          membership: 'leave',
+        },
+        state_key: '@guest-userId1:matrix.org',
+      };
+      await guestMemberService.processMember(roomId, memberEvent);
+
+      expect(
+        getArgsFromCaptor(capture(matrixClientMock.sendStateEvent)).map(
+          ([, , , content]) => content,
+        ),
+      ).toEqual([
+        {
+          users: {
+            [botUserId]: botPowerLevel,
+          },
+          users_default: 25,
+          events: {},
+          events_default: 0,
+          state_default: 50,
+          ban: 50,
+          kick: 50,
+          redact: 50,
+          invite: 0,
+        },
+      ]);
+    },
+  );
+
+  test('does not assign power level to guest when guest joins and bot has power but guest change power level is disabled', async () => {
+    appConfig.enable_guest_user_power_level_change = false;
+
+    when(
+      matrixClientMock.getRoomStateEvent(
+        roomId,
+        StateEventName.M_ROOM_POWER_LEVELS_EVENT,
+        '',
+      ),
+    ).thenResolve({
+      users: {
+        [botUserId]: 50,
+      },
+      users_default: 25,
+      events: {},
+      events_default: 0,
+      state_default: 50,
+      ban: 50,
+      kick: 50,
+      redact: 50,
+      invite: 0,
+    } satisfies PowerLevelsEventContent);
+
+    const memberEvent: IStateEvent<MembershipEventContent> = {
+      event_id: '$eventId1',
+      origin_server_ts: Date.now(),
+      sender: '@guest-userId1:matrix.org',
+      type: StateEventName.M_ROOM_MEMBER_EVENT,
+      content: {
+        membership: 'join',
+      },
+      state_key: '@guest-userId1:matrix.org',
+    };
+    await guestMemberService.processMember(roomId, memberEvent);
+
+    expect(
+      getArgsFromCaptor(capture(matrixClientMock.sendStateEvent)).map(
+        ([, , , content]) => content,
+      ),
+    ).toEqual([]);
+  });
+
+  test('does not assign power level to guest when guest joins but no power level event', async () => {
+    when(
+      matrixClientMock.getRoomStateEvent(
+        roomId,
+        StateEventName.M_ROOM_POWER_LEVELS_EVENT,
+        '',
+      ),
+    ).thenThrow(new Error('Event not found'));
+
+    const memberEvent: IStateEvent<MembershipEventContent> = {
+      event_id: '$eventId1',
+      origin_server_ts: Date.now(),
+      sender: '@guest-userId1:matrix.org',
+      type: StateEventName.M_ROOM_MEMBER_EVENT,
+      content: {
+        membership: 'join',
+      },
+      state_key: '@guest-userId1:matrix.org',
+    };
+    await guestMemberService.processMember(roomId, memberEvent);
+
+    expect(
+      getArgsFromCaptor(capture(matrixClientMock.sendStateEvent)).map(
+        ([, , , content]) => content,
+      ),
+    ).toEqual([]);
+  });
+
+  test('does not assign power level to guest when guest joins but bot has no power to change power level', async () => {
+    when(
+      matrixClientMock.getRoomStateEvent(
+        roomId,
+        StateEventName.M_ROOM_POWER_LEVELS_EVENT,
+        '',
+      ),
+    ).thenResolve({
+      users: {
+        [botUserId]: 50,
+      },
+      users_default: 25,
+      events: {
+        'm.room.power_levels': 100,
+      },
+      events_default: 0,
+      state_default: 50,
+      ban: 50,
+      kick: 50,
+      redact: 50,
+      invite: 0,
+    } satisfies PowerLevelsEventContent);
+
+    const memberEvent: IStateEvent<MembershipEventContent> = {
+      event_id: '$eventId1',
+      origin_server_ts: Date.now(),
+      sender: '@guest-userId1:matrix.org',
+      type: StateEventName.M_ROOM_MEMBER_EVENT,
+      content: {
+        membership: 'join',
+      },
+      state_key: '@guest-userId1:matrix.org',
+    };
+    await guestMemberService.processMember(roomId, memberEvent);
+
+    expect(
+      getArgsFromCaptor(capture(matrixClientMock.sendStateEvent)).map(
+        ([, , , content]) => content,
+      ),
+    ).toEqual([]);
+  });
+
+  test('does not delete power level of guest when guest leaves and bot has power but delete is disabled', async () => {
+    appConfig.guest_user_delete_power_level_on_leave = false;
+
+    when(
+      matrixClientMock.getRoomStateEvent(
+        roomId,
+        StateEventName.M_ROOM_POWER_LEVELS_EVENT,
+        '',
+      ),
+    ).thenResolve({
+      users: {
+        [botUserId]: 50,
+        '@guest-userId1:matrix.org': 0,
+      },
+      users_default: 25,
+      events: {},
+      events_default: 0,
+      state_default: 50,
+      ban: 50,
+      kick: 50,
+      redact: 50,
+      invite: 0,
+    } satisfies PowerLevelsEventContent);
+
+    const memberEvent: IStateEvent<MembershipEventContent> = {
+      event_id: '$eventId1',
+      origin_server_ts: Date.now(),
+      sender: '@guest-userId1:matrix.org',
+      type: StateEventName.M_ROOM_MEMBER_EVENT,
+      content: {
+        membership: 'leave',
+      },
+      state_key: '@guest-userId1:matrix.org',
+    };
+    await guestMemberService.processMember(roomId, memberEvent);
+
+    expect(
+      getArgsFromCaptor(capture(matrixClientMock.sendStateEvent)).map(
+        ([, , , content]) => content,
+      ),
+    ).toEqual([]);
+  });
+
+  test('does not assign power level to not a guest user when user joins and bot has power', async () => {
+    when(
+      matrixClientMock.getRoomStateEvent(
+        roomId,
+        StateEventName.M_ROOM_POWER_LEVELS_EVENT,
+        '',
+      ),
+    ).thenResolve({
+      users: {
+        [botUserId]: 50,
+      },
+      users_default: 25,
+      events: {},
+      events_default: 0,
+      state_default: 50,
+      ban: 50,
+      kick: 50,
+      redact: 50,
+      invite: 0,
+    } satisfies PowerLevelsEventContent);
+
+    const memberEvent: IStateEvent<MembershipEventContent> = {
+      event_id: '$eventId1',
+      origin_server_ts: Date.now(),
+      sender: '@userId1:matrix.org',
+      type: StateEventName.M_ROOM_MEMBER_EVENT,
+      content: {
+        membership: 'join',
+      },
+      state_key: '@userId1:matrix.org',
+    };
+    await guestMemberService.processMember(roomId, memberEvent);
+
+    expect(
+      getArgsFromCaptor(capture(matrixClientMock.sendStateEvent)).map(
+        ([, , , content]) => content,
+      ),
+    ).toEqual([]);
+  });
+
+  test.each([0, 50])(
+    'does not delete power level of not a guest user when user (power level: %s) leaves and bot has power',
+    async (userPowerLevel) => {
+      when(
+        matrixClientMock.getRoomStateEvent(
+          roomId,
+          StateEventName.M_ROOM_POWER_LEVELS_EVENT,
+          '',
+        ),
+      ).thenResolve({
+        users: {
+          [botUserId]: 50,
+          '@userId1:matrix.org': userPowerLevel,
+        },
+        users_default: 25,
+        events: {},
+        events_default: 0,
+        state_default: 50,
+        ban: 50,
+        kick: 50,
+        redact: 50,
+        invite: 0,
+      } satisfies PowerLevelsEventContent);
+
+      const memberEvent: IStateEvent<MembershipEventContent> = {
+        event_id: '$eventId1',
+        origin_server_ts: Date.now(),
+        sender: '@userId1:matrix.org',
+        type: StateEventName.M_ROOM_MEMBER_EVENT,
+        content: {
+          membership: 'leave',
+        },
+        state_key: '@userId1:matrix.org',
+      };
+      await guestMemberService.processMember(roomId, memberEvent);
+
+      expect(
+        getArgsFromCaptor(capture(matrixClientMock.sendStateEvent)).map(
+          ([, , , content]) => content,
+        ),
+      ).toEqual([]);
+    },
+  );
+
+  test('does not assign power level to guest when guest joins and bot has power but guest power level equals users_default', async () => {
+    appConfig.guest_user_default_power_level = 25;
+
+    when(
+      matrixClientMock.getRoomStateEvent(
+        roomId,
+        StateEventName.M_ROOM_POWER_LEVELS_EVENT,
+        '',
+      ),
+    ).thenResolve({
+      users: {
+        [botUserId]: 50,
+      },
+      users_default: 25,
+      events: {},
+      events_default: 0,
+      state_default: 50,
+      ban: 50,
+      kick: 50,
+      redact: 50,
+      invite: 0,
+    } satisfies PowerLevelsEventContent);
+
+    const memberEvent: IStateEvent<MembershipEventContent> = {
+      event_id: '$eventId1',
+      origin_server_ts: Date.now(),
+      sender: '@guest-userId1:matrix.org',
+      type: StateEventName.M_ROOM_MEMBER_EVENT,
+      content: {
+        membership: 'join',
+      },
+      state_key: '@guest-userId1:matrix.org',
+    };
+    await guestMemberService.processMember(roomId, memberEvent);
+
+    expect(
+      getArgsFromCaptor(capture(matrixClientMock.sendStateEvent)).map(
+        ([, , , content]) => content,
+      ),
+    ).toEqual([]);
+  });
+
+  test('does not delete power level of guest when guest leaves and bot has power but guest power level equals users_default', async () => {
+    appConfig.guest_user_default_power_level = 25;
+
+    when(
+      matrixClientMock.getRoomStateEvent(
+        roomId,
+        StateEventName.M_ROOM_POWER_LEVELS_EVENT,
+        '',
+      ),
+    ).thenResolve({
+      users: {
+        [botUserId]: 50,
+        '@guest-userId1:matrix.org': 0,
+      },
+      users_default: 25,
+      events: {},
+      events_default: 0,
+      state_default: 50,
+      ban: 50,
+      kick: 50,
+      redact: 50,
+      invite: 0,
+    } satisfies PowerLevelsEventContent);
+
+    const memberEvent: IStateEvent<MembershipEventContent> = {
+      event_id: '$eventId1',
+      origin_server_ts: Date.now(),
+      sender: '@guest-userId1:matrix.org',
+      type: StateEventName.M_ROOM_MEMBER_EVENT,
+      content: {
+        membership: 'leave',
+      },
+      state_key: '@guest-userId1:matrix.org',
+    };
+    await guestMemberService.processMember(roomId, memberEvent);
+
+    expect(
+      getArgsFromCaptor(capture(matrixClientMock.sendStateEvent)).map(
+        ([, , , content]) => content,
+      ),
+    ).toEqual([]);
+  });
+});

--- a/matrix-meetings-bot/test/util/MockUtils.ts
+++ b/matrix-meetings-bot/test/util/MockUtils.ts
@@ -54,7 +54,7 @@ export function createAppConfig(): IAppConfiguration {
     matrix_filter_apply: false,
     matrix_filter_timeline_limit: 10,
     enable_guest_user_power_level_change: false,
-    guest_user_id_prefix: 'guest-',
+    guest_user_prefix: '@guest-',
     guest_user_default_power_level: 0,
     guest_user_delete_power_level_on_leave: true,
   };

--- a/matrix-meetings-bot/test/util/MockUtils.ts
+++ b/matrix-meetings-bot/test/util/MockUtils.ts
@@ -53,6 +53,10 @@ export function createAppConfig(): IAppConfiguration {
     calendar_room_name: '',
     matrix_filter_apply: false,
     matrix_filter_timeline_limit: 10,
+    enable_guest_user_power_level_change: false,
+    guest_user_id_prefix: 'guest-',
+    guest_user_default_power_level: 0,
+    guest_user_delete_power_level_on_leave: true,
   };
 }
 


### PR DESCRIPTION
This PR updates the bot to be able to change power level of the guest users when they join the room

<img width="582" alt="Screenshot 2023-11-21 at 09 34 57" src="https://github.com/nordeck/matrix-meetings/assets/9369306/15f146c7-13bf-4edb-8fcb-d7c30b94816a">


<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [x] Added or updated documentation.
- [x] Tests for new functionality and regression tests for bug fixes.
- [x] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
