### PR TITLE
Reduce PR noise by allowing rebase

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     open-pull-requests-limit: 15
-    rebase-strategy: 'disabled'
+    rebase-strategy: 'auto'
     schedule:
       interval: 'weekly'
     groups:
@@ -38,18 +38,18 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     open-pull-requests-limit: 15
-    rebase-strategy: 'disabled'
+    rebase-strategy: 'auto'
     schedule:
       interval: 'weekly'
   - package-ecosystem: 'docker'
     directory: '/matrix-meetings-widget'
     open-pull-requests-limit: 15
-    rebase-strategy: 'disabled'
+    rebase-strategy: 'auto'
     schedule:
       interval: 'weekly'
   - package-ecosystem: 'docker'
     directory: '/matrix-meetings-bot'
     open-pull-requests-limit: 15
-    rebase-strategy: 'disabled'
+    rebase-strategy: 'auto'
     schedule:
       interval: 'weekly'


### PR DESCRIPTION
Allows rebases which should reduce PRs getting recreated when the version is bumped further