### PR TITLE
Use Debian Bookworm and Node 20 LTS for the bot image

### DIFF
--- a/.changeset/light-points-study.md
+++ b/.changeset/light-points-study.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-meetings-bot': patch
+---
+
+Use Node.JS 20 LTS and Debian Bookworm for the bot image

--- a/matrix-meetings-bot/Dockerfile
+++ b/matrix-meetings-bot/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-bullseye-slim AS node_modules
+FROM node:20-bookworm-slim AS node_modules
 WORKDIR /build
 COPY package.json yarn.lock ./
 COPY matrix-meetings-bot/package.json ./matrix-meetings-bot/
@@ -6,7 +6,7 @@ COPY packages/calendar/package.json ./packages/calendar/package.json
 COPY packages/calendar/lib ./packages/calendar/lib
 RUN yarn install --production --frozen-lockfile --network-timeout 1000000
 
-FROM node:22-bullseye-slim
+FROM node:20-bookworm-slim
 ENV NODE_ENV=production
 WORKDIR /app
 RUN set -x\


### PR DESCRIPTION
- We use Node 20 for the CI. So let's use it for the image too
- Update Debian to Bookworm, because it supports s390x

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
