### PR TITLE
Add improved SBOM reports

### DIFF
--- a/.changeset/thin-seals-move.md
+++ b/.changeset/thin-seals-move.md
@@ -1,0 +1,6 @@
+---
+'@nordeck/matrix-meetings-widget': patch
+'@nordeck/matrix-meetings-bot': patch
+---
+
+Adds SBOM report to widget, build and release assets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
           image-ref: ${{ env.IMAGE_REF }}
           github-pat: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload SBOM report as a build artifcat
+      - name: Upload SBOM report as a build artifact
         uses: actions/upload-artifact@v4
         with:
           name: matrix-meetings-widget-sbom-spdx-report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,9 +90,30 @@ jobs:
         with:
           push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'pull_request' && secrets.GH_APP_OS_APP_ID != '' }}
           context: ./matrix-meetings-widget/
+          build-contexts: |
+            root=./
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64,linux/s390x
+
+      - name: Run Trivy to get an SBOM report of the container
+        env:
+          IMAGE_REF: ${{ env.DOCKER_IMAGE }}@${{ steps.dockerBuild.outputs.digest }}
+        uses: aquasecurity/trivy-action@0.29.0
+        with:
+          scan-type: 'image'
+          scanners: 'license'
+          format: 'spdx-json'
+          output: 'matrix-meetings-widget.sbom.spdx.json'
+          image-ref: ${{ env.IMAGE_REF }}
+          github-pat: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload SBOM report as a build artifcat
+        uses: actions/upload-artifact@v4
+        with:
+          name: matrix-meetings-widget-sbom-spdx-report
+          path: 'matrix-meetings-widget.sbom.spdx.json'
+          retention-days: 30
 
   build-bot:
     runs-on: ubuntu-latest
@@ -182,6 +203,25 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64,linux/s390x
 
+      - name: Run Trivy to get an SBOM report of the container
+        env:
+          IMAGE_REF: ${{ env.DOCKER_IMAGE }}@${{ steps.dockerBuild.outputs.digest }}
+        uses: aquasecurity/trivy-action@0.29.0
+        with:
+          scan-type: 'image'
+          scanners: 'license'
+          format: 'spdx-json'
+          output: 'matrix-meetings-bot.sbom.spdx.json'
+          image-ref: ${{ env.IMAGE_REF }}
+          github-pat: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload SBOM report as a build artifcat
+        uses: actions/upload-artifact@v4
+        with:
+          name: matrix-meetings-bot-sbom-spdx-report
+          path: 'matrix-meetings-bot.sbom.spdx.json'
+          retention-days: 30
+
   run-changesets:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
@@ -254,6 +294,8 @@ jobs:
         id: dockerBuildWidget
         with:
           context: ./matrix-meetings-widget/
+          build-contexts: |
+            root=./
 
       - name: Docker build bot
         uses: docker/build-push-action@v6

--- a/.github/workflows/publish-release-bot.yml
+++ b/.github/workflows/publish-release-bot.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      contents: read
+      contents: write
       packages: write
       id-token: write
     env:
@@ -67,6 +67,25 @@ jobs:
           tags: ${{ steps.meta-new-tags.outputs.tags }}
           labels: ${{ steps.meta-new-tags.outputs.labels }}
           platforms: linux/amd64,linux/arm64,linux/s390x
+
+      - name: Run Trivy to get an SBOM report of the container
+        env:
+          IMAGE_REF: ${{ env.DOCKER_IMAGE }}@${{ steps.build_and_push.outputs.digest }}
+        uses: aquasecurity/trivy-action@0.29.0
+        with:
+          scan-type: 'image'
+          scanners: 'license'
+          format: 'spdx-json'
+          output: 'sbom.spdx.json'
+          image-ref: ${{ env.IMAGE_REF }}
+          github-pat: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload SBOM to release assets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref_name }}
+        run: |
+          gh release upload "$tag" sbom.spdx.json --repo="$GITHUB_REPOSITORY"
 
       - name: Sign the images with GitHub OIDC Token
         env:

--- a/.github/workflows/publish-release-widget.yml
+++ b/.github/workflows/publish-release-widget.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      contents: read
+      contents: write
       packages: write
       id-token: write
     env:
@@ -67,6 +67,25 @@ jobs:
           tags: ${{ steps.meta-new-tags.outputs.tags }}
           labels: ${{ steps.meta-new-tags.outputs.labels }}
           platforms: linux/amd64,linux/arm64,linux/s390x
+
+      - name: Run Trivy to get an SBOM report of the container
+        env:
+          IMAGE_REF: ${{ env.DOCKER_IMAGE }}@${{ steps.build_and_push.outputs.digest }}
+        uses: aquasecurity/trivy-action@0.29.0
+        with:
+          scan-type: 'image'
+          scanners: 'license'
+          format: 'spdx-json'
+          output: 'sbom.spdx.json'
+          image-ref: ${{ env.IMAGE_REF }}
+          github-pat: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload SBOM to release assets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref_name }}
+        run: |
+          gh release upload "$tag" sbom.spdx.json --repo="$GITHUB_REPOSITORY"
 
       - name: Sign the images with GitHub OIDC Token
         env:

--- a/README.md
+++ b/README.md
@@ -122,10 +122,22 @@ docker run --rm -p 3000:3000 ghcr.io/nordeck/matrix-meetings-bot:latest
 
 We also provide [HELM charts](./charts/).
 
-## Verify the Container Images
+## Supply Chain Security
+
+To ensure transparency and security in our software supply chain, we provide comprehensive Software Bill of Materials (SBOM) reports for this project and signed container images.
+
+### SBOM Reports
+
+We provide SBOM reports within the widget container and as a release artifact.
+
+- The generated SBOM report is available alongside the hosted widget assets, and can be found at `<DEPLOYMENT-URL>/sbom.spdx.json`, or via the filesystem at `/usr/share/nginx/html/sbom.spdx.json`
+- For the bot container, you will find the SBOM at `/usr/local/share/doc/matrix-meetings-bot.sbom.spdx.json`
+- Each GitHub release has a corresponding image SBOM scan report file attached as a release asset
+
+### Signed Container Images
 
 The container images releases are signed by [cosign](https://github.com/sigstore/cosign) using identity-based ("keyless") signing and transparency.
-Execute the following command to verify the signature of a container image:
+Execute the following command to verify the signature of the container images:
 
 ```sh
 cosign verify \

--- a/matrix-meetings-bot/Dockerfile
+++ b/matrix-meetings-bot/Dockerfile
@@ -1,25 +1,38 @@
-FROM node:20-bookworm-slim AS node_modules
+FROM aquasec/trivy:latest AS scanner
+
+# Copy yarn.lock to run SBOM scan
+COPY yarn.lock /tmp
+RUN trivy fs --format spdx-json --scanners "license" /tmp/yarn.lock > /tmp/sbom.spdx.json
+
+FROM node:20-bookworm-slim AS builder
+
 WORKDIR /build
+
 COPY package.json yarn.lock ./
 COPY matrix-meetings-bot/package.json ./matrix-meetings-bot/
 COPY packages/calendar/package.json ./packages/calendar/package.json
 COPY packages/calendar/lib ./packages/calendar/lib
 RUN yarn install --production --frozen-lockfile --network-timeout 1000000
 
+# Runtime image
 FROM node:20-bookworm-slim
+
 ENV NODE_ENV=production
 WORKDIR /app
 
 #  update npm to address CVE-2024-21538
 RUN npm install -g npm@10.9.2
 
+# Add SBOM to the public folder
+COPY --from=scanner /tmp/sbom.spdx.json /usr/local/share/doc/matrix-meetings-bot.sbom.spdx.json
+
 RUN set -x\
     && mkdir /app/storage \
     && chown -R 101:0 /app/storage \
     && chmod -R g+w /app/storage
 USER 101
-COPY --from=node_modules /build/node_modules/ ./node_modules
-COPY --from=node_modules /build/packages/calendar/ ./packages/calendar/
+COPY --from=builder /build/node_modules/ ./node_modules
+COPY --from=builder /build/packages/calendar/ ./packages/calendar/
 COPY matrix-meetings-bot/conf ./conf
 COPY matrix-meetings-bot/lib ./lib
 CMD ["node", "./lib/index.js"]

--- a/matrix-meetings-widget/Dockerfile
+++ b/matrix-meetings-widget/Dockerfile
@@ -1,6 +1,15 @@
+FROM aquasec/trivy:latest AS scanner
+
+# Copy yarn.lock to run SBOM scan
+COPY --from=root yarn.lock /tmp
+RUN trivy fs --format spdx-json --scanners "license" /tmp/yarn.lock > /tmp/sbom.spdx.json
+
 FROM ghcr.io/nordeck/matrix-widget-toolkit/widget-server:1.1.0@sha256:85b4bf57747788ef1ac3472a826502219be20e7b1fffff6193ad4c0b0ccbc42d
 
-ADD build /usr/share/nginx/html/
+ADD --chown=nginx:nginx build /usr/share/nginx/html/
+
+# Add SBOM to the public folder
+COPY --from=scanner --chown=nginx:nginx /tmp/sbom.spdx.json /usr/share/nginx/html/sbom.spdx.json
 
 # Allow loading images from the home server.
 ENV CSP_IMG_SRC="\${REACT_APP_HOME_SERVER_URL}"

--- a/matrix-meetings-widget/package.json
+++ b/matrix-meetings-widget/package.json
@@ -73,7 +73,7 @@
   },
   "scripts": {
     "docker": "yarn run docker:build && yarn run docker:run && yarn run docker:remove",
-    "docker:build": "docker build -t nordeck/matrix-meetings-widget .",
+    "docker:build": "docker build --build-context root=../ -t nordeck/matrix-meetings-widget .",
     "docker:run": "dotenv -c development -- docker run -e REACT_APP_API_BASE_URL -p 3000:8080 --name matrix-meetings-widget nordeck/matrix-meetings-widget",
     "docker:stop": "docker stop matrix-meetings-widget",
     "docker:remove": "yarn run docker:stop && docker rm -v matrix-meetings-widget",


### PR DESCRIPTION
<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

This PR improves the SBOM reporting process by:

- adding a `yarn.lock` SBOM scan report within the hosted widget assets at `<URL>/sbom.spdx.json`
- adding a `yarn.lock` SBOM scan report of the bot at `/usr/local/share/doc/`
- adding an image SBOM scan report artifact to every CI build (see [example](https://github.com/nordeck/matrix-neoboard/actions/runs/12788724626#artifacts))
- adding an image SBOM scan report as a release asset when publishing a new release

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [X] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [X] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
