### PR TITLE
Add podman support to e2e tests

### DIFF
--- a/e2e/src/deploy/synapse/index.ts
+++ b/e2e/src/deploy/synapse/index.ts
@@ -79,7 +79,8 @@ export async function startSynapse({
   const synapseUrl = `http://${container.getHost()}:${container.getMappedPort(
     8008,
   )}`;
-  const synapseHostUrl = `http://${container.getIpAddress('bridge')}:8008`;
+  const ipAddress = getIpAddress(container);
+  const synapseHostUrl = `http://${ipAddress}:8008`;
 
   console.log('Synapse running at', synapseUrl);
 
@@ -92,4 +93,16 @@ export async function stopSynapse() {
 
     console.log('Stopped synapse');
   }
+}
+
+function getIpAddress(container: StartedTestContainer): string {
+  try {
+    // First try to return the Docker IP address
+    return container.getIpAddress('bridge');
+  } catch {
+    // Ignore
+  }
+
+  // Try the Podman IP address otherwise
+  return container.getIpAddress('podman');
 }


### PR DESCRIPTION
Same as we already use here https://github.com/nordeck/element-web-modules/blob/main/e2e/src/deploy/synapse/index.ts#L150

<!-- Thank you for creating a Pull Request!


     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).

PX4-77