### PR TITLE
Do not build the calendar package any more

### DIFF
--- a/packages/calendar/.eslintignore
+++ b/packages/calendar/.eslintignore
@@ -1,2 +1,1 @@
 coverage/
-lib/

--- a/packages/calendar/.gitignore
+++ b/packages/calendar/.gitignore
@@ -1,2 +1,1 @@
-/lib
 /coverage

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -10,7 +10,7 @@
   "main": "lib/index.js",
   "scripts": {
     "docker:build": "echo \"Nothing to build\"",
-    "build": "tsc",
+    "build": "echo \"Nothing to build\"",
     "depcheck": "depcheck",
     "test": "jest --watch",
     "test:all": "jest --coverage --watchAll=false",

--- a/packages/calendar/tsconfig.json
+++ b/packages/calendar/tsconfig.json
@@ -1,10 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "module": "commonjs",
-    "outDir": "lib",
-    "rootDir": "src",
-    "noEmit": false
+    "noEmit": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
It is marked as private and is only used by other packages within this repo. There is no need for a build of this package.

This does not change anything → no changelog
It makes things easier with the ongoing Vite migration. One less package to build.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).

PX4-77