### PR TITLE
Fix dependabot.yml ordering

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,12 +12,6 @@ updates:
     schedule:
       interval: 'weekly'
     groups:
-      production-dependencies:
-        dependency-type: 'production'
-      development-dependencies:
-        dependency-type: 'development'
-        exclude-patterns:
-          - '@nestjs/*'
       matrix-widget-toolkit:
         # Group all dependencies that are managed by the widget toolkit
         patterns:
@@ -37,6 +31,10 @@ updates:
       fullcalendar:
         patterns:
           - '@fullcalendar/*'
+      production-dependencies:
+        dependency-type: 'production'
+      development-dependencies:
+        dependency-type: 'development'
   - package-ecosystem: 'github-actions'
     directory: '/'
     open-pull-requests-limit: 15


### PR DESCRIPTION
[Groups are evaluated first-match](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates#example-1-three-version-update-groups), so before this PR our groups were basically useless. Moving the prod deps and dev deps groups down means they will "catch" all updates that don't match the more specific groups.