### PR TITLE
Improve Room 12 support. Use synapse capabilities endpoint.

### DIFF
--- a/.changeset/blue-worms-kiss.md
+++ b/.changeset/blue-worms-kiss.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-meetings-bot': patch
+---
+
+Use `/_matrix/client/v3/capabilities` endpoint to retrieve synapse room default version. Deprecate `DEFAULT_ROOM_VERSION` option.

--- a/.changeset/blue-worms-kiss.md
+++ b/.changeset/blue-worms-kiss.md
@@ -2,4 +2,4 @@
 '@nordeck/matrix-meetings-bot': patch
 ---
 
-Improve Matrix Room Version 12 support by using `/_matrix/client/v3/capabilities` endpoint to retrieve synapse room default version. Deprecate `DEFAULT_ROOM_VERSION` option.
+Improve Matrix Room Version 12 support by using `/_matrix/client/v3/capabilities` endpoint to retrieve synapse room default version. The `DEFAULT_ROOM_VERSION` option is not needed and is deleted.

--- a/.changeset/blue-worms-kiss.md
+++ b/.changeset/blue-worms-kiss.md
@@ -2,4 +2,4 @@
 '@nordeck/matrix-meetings-bot': patch
 ---
 
-Use `/_matrix/client/v3/capabilities` endpoint to retrieve synapse room default version. Deprecate `DEFAULT_ROOM_VERSION` option.
+Improve Matrix Room Version 12 support by using `/_matrix/client/v3/capabilities` endpoint to retrieve synapse room default version. Deprecate `DEFAULT_ROOM_VERSION` option.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -149,10 +149,6 @@ GUEST_USER_DEFAULT_POWER_LEVEL=0
 
 # optional - if true, bot deletes guest user power level from power level event when guest user leaves the room. It makes sure power level is cleaned up if guest user is deactivated later.
 GUEST_USER_DELETE_POWER_LEVEL_ON_LEAVE=true
-
-# Deprecated! Bot uses '/_matrix/client/v3/capabilities' endpoint to get synapse default room version.
-# optional - configure a default room version configured for synapse. It is used to make room version specific power levels changes when rooms are created the by the bot. It supports room version 12. It defaults to room 10 version behaviour. The room creator gets power level 150 when the room version is 12.
-DEFAULT_ROOM_VERSION=
 #
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -150,6 +150,7 @@ GUEST_USER_DEFAULT_POWER_LEVEL=0
 # optional - if true, bot deletes guest user power level from power level event when guest user leaves the room. It makes sure power level is cleaned up if guest user is deactivated later.
 GUEST_USER_DELETE_POWER_LEVEL_ON_LEAVE=true
 
+# Deprecated! Bot uses '/_matrix/client/v3/capabilities' endpoint to get synapse default room version.
 # optional - configure a default room version configured for synapse. It is used to make room version specific power levels changes when rooms are created the by the bot. It supports room version 12. It defaults to room 10 version behaviour. The room creator gets power level 150 when the room version is 12.
 DEFAULT_ROOM_VERSION=
 #

--- a/matrix-meetings-bot/src/IAppConfiguration.ts
+++ b/matrix-meetings-bot/src/IAppConfiguration.ts
@@ -63,6 +63,4 @@ export interface IAppConfiguration {
   guest_user_prefix: string;
   guest_user_default_power_level: number;
   guest_user_delete_power_level_on_leave: boolean;
-
-  default_room_version?: string;
 }

--- a/matrix-meetings-bot/src/app.module.ts
+++ b/matrix-meetings-bot/src/app.module.ts
@@ -41,6 +41,7 @@ import { EventContentRenderer } from './EventContentRenderer';
 import { IAppConfiguration } from './IAppConfiguration';
 import { ModuleProviderToken } from './ModuleProviderToken';
 import { JitsiClient } from './client/JitsiClient';
+import { MatrixClientAdapter } from './client/MatrixClientAdapter';
 import { MeetingClient } from './client/MeetingClient';
 import { ReactionClient } from './client/ReactionClient';
 import { WidgetClient } from './client/WidgetClient';
@@ -262,6 +263,7 @@ const i18nFactory: FactoryProvider<void> = {
     EventContentRenderer,
     JitsiClient,
     MeetingClient,
+    MatrixClientAdapter,
     ReactionClient,
     WidgetClient,
     CommandService,

--- a/matrix-meetings-bot/src/client/MatrixClientAdapter.test.ts
+++ b/matrix-meetings-bot/src/client/MatrixClientAdapter.test.ts
@@ -31,7 +31,6 @@ describe('MatrixClientAdapter', () => {
                   'm.room_versions': {
                     default: '12',
                     available: {},
-                    'org.matrix.msc3244.room_capabilities': {},
                   },
                   'm.change_password': { enabled: true },
                   'm.set_displayname': { enabled: true },

--- a/matrix-meetings-bot/src/client/MatrixClientAdapter.test.ts
+++ b/matrix-meetings-bot/src/client/MatrixClientAdapter.test.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MatrixClient } from 'matrix-bot-sdk';
+import { MatrixClientAdapter } from './MatrixClientAdapter';
+
+jest.mock('matrix-bot-sdk');
+
+describe('MatrixClientAdapter', () => {
+  beforeEach(() => {
+    jest
+      .spyOn(MatrixClient.prototype, 'doRequest')
+      .mockImplementation((method, endpoint) => {
+        const response =
+          endpoint === '/_matrix/client/v3/capabilities'
+            ? {
+                capabilities: {
+                  'm.room_versions': {
+                    default: '12',
+                    available: {},
+                    'org.matrix.msc3244.room_capabilities': {},
+                  },
+                  'm.change_password': { enabled: true },
+                  'm.set_displayname': { enabled: true },
+                  'm.set_avatar_url': { enabled: true },
+                  'm.3pid_changes': { enabled: true },
+                  'm.get_login_token': { enabled: false },
+                  'm.profile_fields': { enabled: true },
+                },
+              }
+            : undefined;
+
+        return Promise.resolve(response);
+      });
+  });
+
+  it('should get synapse default room version via capabilities endpoint', async () => {
+    const matrixClient = new MatrixClient('https://example.com', 'token123');
+    const matrixClientAdapter = new MatrixClientAdapter(matrixClient);
+
+    expect(
+      await matrixClientAdapter.getCapabilitiesDefaultRoomVersion(),
+    ).toEqual('12');
+    expect(MatrixClient.prototype.doRequest).toHaveBeenCalledWith(
+      'GET',
+      '/_matrix/client/v3/capabilities',
+    );
+    expect(MatrixClient.prototype.doRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('should get and cache synapse default room version via capabilities endpoint', async () => {
+    jest.useFakeTimers();
+
+    const matrixClient = new MatrixClient('https://example.com', 'token123');
+    const matrixClientAdapter = new MatrixClientAdapter(matrixClient);
+
+    expect(
+      await matrixClientAdapter.getCapabilitiesDefaultRoomVersion(),
+    ).toEqual('12');
+    expect(MatrixClient.prototype.doRequest).toHaveBeenCalledWith(
+      'GET',
+      '/_matrix/client/v3/capabilities',
+    );
+    expect(MatrixClient.prototype.doRequest).toHaveBeenCalledTimes(1);
+
+    expect(
+      await matrixClientAdapter.getCapabilitiesDefaultRoomVersion(),
+    ).toEqual('12');
+    expect(MatrixClient.prototype.doRequest).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(7200000); // 2 hours
+
+    expect(
+      await matrixClientAdapter.getCapabilitiesDefaultRoomVersion(),
+    ).toEqual('12');
+    expect(MatrixClient.prototype.doRequest).toHaveBeenCalledTimes(2);
+  });
+});

--- a/matrix-meetings-bot/src/client/MatrixClientAdapter.ts
+++ b/matrix-meetings-bot/src/client/MatrixClientAdapter.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Injectable } from '@nestjs/common';
+import { MatrixClient } from 'matrix-bot-sdk';
+
+// Follows what matrix bot sdk doing for versions: https://github.com/turt2live/matrix-bot-sdk/blob/ac53f0fb625911b87b3c1427661824b9a38d0514/src/MatrixClient.ts#L50
+const defaultRoomVersionCacheMs = 7200000; // 2 hours
+
+@Injectable()
+export class MatrixClientAdapter {
+  private cachedDefaultRoomVersion?: string;
+  private defaultRoomVersionLastFetched: number = 0;
+
+  constructor(private matrixClient: MatrixClient) {}
+
+  /**
+   * Retrieves synapse default room version using '/_matrix/client/v3/capabilities' endpoint.
+   * @returns {Promise<string>} Resolves to the synapse default room version
+   */
+  public async getCapabilitiesDefaultRoomVersion(): Promise<string> {
+    let defaultRoomVersion: string;
+
+    if (
+      !this.cachedDefaultRoomVersion ||
+      Date.now() - this.defaultRoomVersionLastFetched >=
+        defaultRoomVersionCacheMs
+    ) {
+      const response = await this.matrixClient.doRequest(
+        'GET',
+        '/_matrix/client/v3/capabilities',
+      );
+      const responseDefaultRoomVersion =
+        response['capabilities']['m.room_versions']['default'];
+      defaultRoomVersion = responseDefaultRoomVersion;
+      this.cachedDefaultRoomVersion = responseDefaultRoomVersion;
+      this.defaultRoomVersionLastFetched = Date.now();
+    } else {
+      defaultRoomVersion = this.cachedDefaultRoomVersion;
+    }
+
+    return defaultRoomVersion;
+  }
+}

--- a/matrix-meetings-bot/src/client/MeetingClient.test.ts
+++ b/matrix-meetings-bot/src/client/MeetingClient.test.ts
@@ -69,6 +69,7 @@ describe('MeetingClient', () => {
               timezone: 'Europe/Berlin',
               userId: '@user-id:example.og',
             },
+            '10',
             60,
             messagingPowerLevel,
           ),
@@ -166,9 +167,9 @@ describe('MeetingClient', () => {
             timezone: 'Europe/Berlin',
             userId: '@user-id:example.og',
           },
+          '12',
           60,
           undefined,
-          '12',
         ),
       ).resolves.toEqual([
         '!new-room-id',
@@ -256,6 +257,7 @@ describe('MeetingClient', () => {
             timezone: 'Europe/Berlin',
             userId: '@user-id:example.og',
           },
+          '10',
           60,
         ),
       ).resolves.toEqual([

--- a/matrix-meetings-bot/src/client/MeetingClient.ts
+++ b/matrix-meetings-bot/src/client/MeetingClient.ts
@@ -85,9 +85,9 @@ export class MeetingClient {
     spaceParentEventContent: ISpaceParentEventContent,
     roomMatrixEvents: DeepReadonly<IRoomMatrixEvents>,
     userContext: IUserContext,
+    defaultRoomVersion: string,
     autoDeletionOffset?: number,
     messagingPowerLevel?: number,
-    defaultRoomVersion?: string,
   ): Promise<
     [string, DeepReadonlyArray<IStateEvent<IElementMembershipEventContent>>]
   > {

--- a/matrix-meetings-bot/src/configuration.ts
+++ b/matrix-meetings-bot/src/configuration.ts
@@ -119,8 +119,6 @@ function createConfiguration() {
       process.env.GUEST_USER_DELETE_POWER_LEVEL_ON_LEAVE,
       true,
     ),
-
-    default_room_version: process.env.DEFAULT_ROOM_VERSION,
   };
 
   return {
@@ -189,8 +187,6 @@ export const ValidationSchema = Joi.object({
   GUEST_USER_PREFIX: Joi.string(),
   GUEST_USER_DEFAULT_POWER_LEVEL: Joi.number(),
   GUEST_USER_DELETE_POWER_LEVEL_ON_LEAVE: Joi.boolean(),
-
-  DEFAULT_ROOM_VERSION: Joi.string(),
 });
 
 export default createConfiguration;

--- a/matrix-meetings-bot/src/service/MeetingService.ts
+++ b/matrix-meetings-bot/src/service/MeetingService.ts
@@ -29,6 +29,7 @@ import {
 } from '../IEventContentParams';
 import { ModuleProviderToken } from '../ModuleProviderToken';
 import { JitsiClient } from '../client/JitsiClient';
+import { MatrixClientAdapter } from '../client/MatrixClientAdapter';
 import { MeetingClient } from '../client/MeetingClient';
 import { WidgetClient } from '../client/WidgetClient';
 import { BreakoutSessionsDto } from '../dto/BreakoutSessionsDto';
@@ -76,6 +77,7 @@ export class MeetingService {
   constructor(
     private jitsiClient: JitsiClient,
     private matrixClient: MatrixClient,
+    private matrixClientAdapter: MatrixClientAdapter,
     private roomMessageService: RoomMessageService,
     private meetingClient: MeetingClient,
     @Inject(ModuleProviderToken.APP_CONFIGURATION)
@@ -164,6 +166,8 @@ export class MeetingService {
       via: [new UserID(await this.matrixClient.getUserId()).domain],
     };
 
+    const defaultRoomVersion =
+      await this.matrixClientAdapter.getCapabilitiesDefaultRoomVersion();
     const [roomId, renderedMemberEventsWithReason]: [
       string,
       DeepReadonlyArray<IStateEvent<IElementMembershipEventContent>>,
@@ -177,7 +181,7 @@ export class MeetingService {
       userContext,
       autoDeletionOffset,
       meetingCreate.messaging_power_level,
-      this.appConfig.default_room_version,
+      defaultRoomVersion,
     );
 
     const promises: Promise<any>[] = [];

--- a/matrix-meetings-bot/src/service/MeetingService.ts
+++ b/matrix-meetings-bot/src/service/MeetingService.ts
@@ -179,9 +179,9 @@ export class MeetingService {
       spaceParentEventContent,
       this.roomMatrixEvents,
       userContext,
+      defaultRoomVersion,
       autoDeletionOffset,
       meetingCreate.messaging_power_level,
-      defaultRoomVersion,
     );
 
     const promises: Promise<any>[] = [];


### PR DESCRIPTION
The Bot is improved to use `/_matrix/client/v3/capabilities` endpoint to retrieve synapse room default version.

`DEFAULT_ROOM_VERSION` configuration option is not needed anymore and is deprecated.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [x] Added or updated documentation.
- [x] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
