### PR TITLE
Update direct message room detection logic

### DIFF
--- a/.changeset/tough-weeks-run.md
+++ b/.changeset/tough-weeks-run.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-meetings-bot': patch
+---
+
+Update direct message room detection logic

--- a/matrix-meetings-bot/src/service/WelcomeWorkflowService.ts
+++ b/matrix-meetings-bot/src/service/WelcomeWorkflowService.ts
@@ -117,9 +117,15 @@ export class WelcomeWorkflowService {
     const roomMemberEvents = room.roomEventsByName(
       StateEventName.M_ROOM_MEMBER_EVENT,
     ) as IStateEvent<MembershipEventContent>[];
-    const botIsDirect = !!roomMemberEvents.find(
-      (e) => e.state_key === this.botId && e.unsigned?.prev_content?.is_direct,
-    );
+
+    // The `is_direct` flag is set either on the content of an invite or in the
+    // prev_content of the updated membership event after the bot joins.
+    const botIsDirect =
+      !!event.content?.is_direct ||
+      !!roomMemberEvents.find(
+        (e) =>
+          e.state_key === this.botId && e.unsigned?.prev_content?.is_direct,
+      );
 
     const roomType: RoomType = botIsDirect
       ? RoomType.CALENDAR_ROOM

--- a/matrix-meetings-bot/test/WelcomeWorkflowService.test.ts
+++ b/matrix-meetings-bot/test/WelcomeWorkflowService.test.ts
@@ -330,6 +330,93 @@ describe('test WelcomeWorkflowService', () => {
     expect(membership).toBe('invite');
   });
 
+  describe('processRoomInvite - direct message detection', () => {
+    let service: WelcomeWorkflowService;
+    let meetingClientMock: MeetingClient;
+    let controlRoomMigrationServiceMock: ControlRoomMigrationService;
+
+    const createInviteEvent = (
+      is_direct?: boolean,
+    ): IStateEvent<MembershipEventContent> => ({
+      ...createMembershipEvent(),
+      sender: USER_ID,
+      content: {
+        membership: 'invite',
+        ...(is_direct === undefined ? {} : { is_direct }),
+      },
+    });
+
+    beforeEach(() => {
+      meetingClientMock = mock(MeetingClient);
+      controlRoomMigrationServiceMock = mock(ControlRoomMigrationService);
+      service = buildWelcomeWorkflowService(instance(clientMock), appConfig, {
+        meetingClient: instance(meetingClientMock),
+        controlRoomMigrationService: instance(controlRoomMigrationServiceMock),
+      });
+      when(meetingClientMock.fetchRoomAsync(ROOM_ID)).thenResolve(
+        new Room(ROOM_ID, []),
+      );
+    });
+
+    it('migrates to a calendar room when the invite event content has is_direct', async () => {
+      await service.processRoomInvite(ROOM_ID, createInviteEvent(true));
+
+      verify(clientMock.joinRoom(ROOM_ID)).once();
+      verify(
+        controlRoomMigrationServiceMock.migrateSingleRoom(
+          anything(),
+          anything(),
+          anything(),
+        ),
+      ).once();
+      verify(clientMock.createRoom(anything())).never();
+    });
+
+    it('migrates to a calendar room when the bot member event has prev_content.is_direct', async () => {
+      const botMemberEvent = {
+        ...createStateEvent(StateEventName.M_ROOM_MEMBER_EVENT, BOT_ID),
+        content: {
+          membership: 'join',
+        },
+        unsigned: {
+          prev_content: {
+            membership: 'invite',
+            is_direct: true,
+          },
+        },
+      };
+      when(meetingClientMock.fetchRoomAsync(ROOM_ID)).thenResolve(
+        new Room(ROOM_ID, [botMemberEvent]),
+      );
+
+      await service.processRoomInvite(ROOM_ID, createInviteEvent());
+
+      verify(
+        controlRoomMigrationServiceMock.migrateSingleRoom(
+          anything(),
+          anything(),
+          anything(),
+        ),
+      ).once();
+      verify(clientMock.createRoom(anything())).never();
+    });
+
+    it('creates a help room when no is_direct flag is present', async () => {
+      when(clientMock.createRoom(anything())).thenResolve('new_room_id');
+
+      await service.processRoomInvite(ROOM_ID, createInviteEvent());
+
+      verify(
+        controlRoomMigrationServiceMock.migrateSingleRoom(
+          anything(),
+          anything(),
+          anything(),
+        ),
+      ).never();
+      verify(clientMock.createRoom(anything())).once();
+    });
+  });
+
   test('processUserLeavePrivateRoom - undefined membership', async () => {
     const service = buildWelcomeWorkflowService(
       instance(clientMock),


### PR DESCRIPTION
When the bot is invited to a room, it checks the membership state events to verify if the room is either a DM or not, in order to setup the calendar widget or create a help room.

The `processRoomInvite` method from `WelcomeWorkflowService` was only looking at a list of state events returned by the client, which should be enough but due to potential race conditions, might not have the updated membership state yet after the join transition, and thus selecting the wrong flow.

It now also checks the actual invite event for the `is_direct` property instead of only looking at the `prev_content` event data that should exist after joining.

This specific issue has surfaced when testing the Meetings Bot with the [openDesk merge request](https://gitlab.opencode.de/bmi/opendesk/deployment/opendesk/-/merge_requests/1330) that pulls in the Element stack from the oficial ESS Helm Charts and is a blocker for moving forward with that process.

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [X] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [X] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
